### PR TITLE
feat(runtime): add Node/Bun runtime abstraction layer

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
         "noExcessiveCognitiveComplexity": "off"
       },
       "performance": {
-        "useTopLevelRegex": "off"
+        "useTopLevelRegex": "off",
+        "noBarrelFile": "off"
       },
       "suspicious": {
         "useAwait": "off"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bin": {
     "resect": "./bin/resect.js"
   },
+  "exports": {
+    ".": "./src/index.ts",
+    "./bun": "./src/runtime/bun.ts",
+    "./node": "./src/runtime/node.ts",
+    "./runtime": "./src/runtime/index.ts"
+  },
   "files": [
     "bin",
     "src",

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -32,6 +32,7 @@ import {
 	findBuildScript,
 	type WorkspaceInfo,
 } from "../core/workspace.ts";
+import { getRuntime } from "../runtime/index.ts";
 import type {
 	MoveError,
 	MoveResult,
@@ -235,10 +236,10 @@ export async function moveModule(
 ): Promise<MoveResult> {
 	const errors: MoveError[] = [];
 	const updatedReferences: UpdatedReference[] = [];
+	const rt = getRuntime();
 
 	// Validate source exists
-	const sourceFile = Bun.file(sourcePath);
-	if (!(await sourceFile.exists())) {
+	if (!(await rt.fs.exists(sourcePath))) {
 		return {
 			success: false,
 			movedFile: { from: sourcePath, to: targetPath },
@@ -254,8 +255,7 @@ export async function moveModule(
 	}
 
 	// Check target doesn't exist
-	const targetFile = Bun.file(targetPath);
-	if (await targetFile.exists()) {
+	if (await rt.fs.exists(targetPath)) {
 		return {
 			success: false,
 			movedFile: { from: sourcePath, to: targetPath },
@@ -325,17 +325,14 @@ export async function moveModule(
 		let targetBarrelAst: ts.SourceFile | undefined;
 		if (workspace) {
 			const destBarrelPath = findDestinationBarrel(targetPath, workspace);
-			if (destBarrelPath) {
-				const destBarrelFile = Bun.file(destBarrelPath);
-				if (await destBarrelFile.exists()) {
-					const barrelContent = await destBarrelFile.text();
-					targetBarrelAst = ts.createSourceFile(
-						destBarrelPath,
-						barrelContent,
-						ts.ScriptTarget.Latest,
-						true
-					);
-				}
+			if (destBarrelPath && (await rt.fs.exists(destBarrelPath))) {
+				const barrelContent = await rt.fs.readFile(destBarrelPath);
+				targetBarrelAst = ts.createSourceFile(
+					destBarrelPath,
+					barrelContent,
+					ts.ScriptTarget.Latest,
+					true
+				);
 			}
 		}
 
@@ -401,15 +398,15 @@ export async function moveModule(
 				updatedReferences.push(...updates);
 				if (!dryRun) {
 					// We'll write this as part of the move
-					await Bun.write(targetPath, newContent);
-					await Bun.file(sourcePath).delete();
+					await rt.fs.writeFile(targetPath, newContent);
+					await rt.fs.deleteFile(sourcePath);
 					fileMoved = true;
 				}
 			} else if (!dryRun) {
 				// No internal changes, just copy
-				const content = await sourceFile.text();
-				await Bun.write(targetPath, content);
-				await Bun.file(sourcePath).delete();
+				const content = await rt.fs.readFile(sourcePath);
+				await rt.fs.writeFile(targetPath, content);
+				await rt.fs.deleteFile(sourcePath);
 				fileMoved = true;
 			}
 		}
@@ -417,9 +414,9 @@ export async function moveModule(
 
 	// If file wasn't moved yet (no internal refs or couldn't parse), copy as-is
 	if (!(fileMoved || dryRun)) {
-		const content = await sourceFile.text();
-		await Bun.write(targetPath, content);
-		await Bun.file(sourcePath).delete();
+		const content = await rt.fs.readFile(sourcePath);
+		await rt.fs.writeFile(targetPath, content);
+		await rt.fs.deleteFile(sourcePath);
 	}
 
 	// Update all referencing files
@@ -453,7 +450,7 @@ export async function moveModule(
 			if (updates.length > 0) {
 				updatedReferences.push(...updates);
 				if (!dryRun) {
-					await Bun.write(filePath, newContent);
+					await rt.fs.writeFile(filePath, newContent);
 				}
 			}
 		} catch (error) {
@@ -494,7 +491,7 @@ export async function moveModule(
 			if (updates.length > 0) {
 				updatedReferences.push(...updates);
 				if (!dryRun) {
-					await Bun.write(barrelPath, newContent);
+					await rt.fs.writeFile(barrelPath, newContent);
 				}
 			}
 		} catch (error) {
@@ -511,9 +508,8 @@ export async function moveModule(
 		const destBarrelPath = findDestinationBarrel(targetPath, workspace);
 		if (destBarrelPath) {
 			try {
-				const destBarrelFile = Bun.file(destBarrelPath);
-				if (await destBarrelFile.exists()) {
-					const barrelContent = await destBarrelFile.text();
+				if (await rt.fs.exists(destBarrelPath)) {
+					const barrelContent = await rt.fs.readFile(destBarrelPath);
 					const { newContent, update } = addExportToDestinationBarrel(
 						barrelContent,
 						targetPath,
@@ -523,7 +519,7 @@ export async function moveModule(
 					if (newContent !== barrelContent) {
 						updatedReferences.push(update);
 						if (!dryRun) {
-							await Bun.write(destBarrelPath, newContent);
+							await rt.fs.writeFile(destBarrelPath, newContent);
 						}
 						if (verbose) {
 							logger.info(

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -15,6 +15,7 @@ import {
 	type TextChange,
 } from "../core/text-changes.ts";
 import { checkAllConflicts } from "../core/verify.ts";
+import { getRuntime } from "../runtime/index.ts";
 import type {
 	ModuleReference,
 	ProjectConfig,
@@ -87,10 +88,10 @@ export async function renameSymbol(
 ): Promise<RenameResult> {
 	const errors: { file: string; message: string }[] = [];
 	const updatedReferences: UpdatedReference[] = [];
+	const rt = getRuntime();
 
 	// Validate file exists
-	const sourceFile = Bun.file(filePath);
-	if (!(await sourceFile.exists())) {
+	if (!(await rt.fs.exists(filePath))) {
 		return {
 			success: false,
 			renamedSymbol: { file: filePath, oldName, newName },
@@ -192,7 +193,7 @@ export async function renameSymbol(
 			...sourceResult.updates.map((u) => ({ ...u, file: filePath }))
 		);
 		if (!dryRun) {
-			await Bun.write(filePath, sourceResult.newContent);
+			await rt.fs.writeFile(filePath, sourceResult.newContent);
 		}
 	}
 
@@ -227,7 +228,7 @@ export async function renameSymbol(
 					...result.updates.map((u) => ({ ...u, file: importingFile }))
 				);
 				if (!dryRun) {
-					await Bun.write(importingFile, result.newContent);
+					await rt.fs.writeFile(importingFile, result.newContent);
 				}
 			}
 		} catch (error) {

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { Glob } from "bun";
 import { logger } from "../cli-logger.ts";
+import { getRuntime } from "../runtime/index.ts";
 import { EXPORT_STATEMENT_PATTERN, removeExtension } from "./constants.ts";
 
 export interface WorkspacePackage {
@@ -113,21 +113,23 @@ async function findWorkspaceRoot(startDir: string): Promise<{
 	while (currentDir !== path.dirname(currentDir)) {
 		// Check for pnpm-workspace.yaml
 		const pnpmWorkspace = path.join(currentDir, "pnpm-workspace.yaml");
-		if (await fileExists(pnpmWorkspace)) {
+		if (await getRuntime().fs.exists(pnpmWorkspace)) {
 			const patterns = await parsePnpmWorkspace(pnpmWorkspace);
 			return { root: currentDir, type: "pnpm", patterns };
 		}
 
 		// Check for package.json with workspaces field (yarn/npm)
 		const packageJson = path.join(currentDir, "package.json");
-		if (await fileExists(packageJson)) {
+		if (await getRuntime().fs.exists(packageJson)) {
 			const pkg = await readPackageJson(packageJson);
 			if (pkg?.workspaces) {
 				const workspaces = pkg.workspaces as string[] | { packages?: string[] };
 				const patterns = Array.isArray(workspaces)
 					? workspaces
 					: (workspaces.packages ?? []);
-				const type = (await fileExists(path.join(currentDir, "yarn.lock")))
+				const type = (await getRuntime().fs.exists(
+					path.join(currentDir, "yarn.lock")
+				))
 					? "yarn"
 					: "npm";
 				return { root: currentDir, type, patterns };
@@ -145,7 +147,7 @@ async function findWorkspaceRoot(startDir: string): Promise<{
  */
 async function parsePnpmWorkspace(filePath: string): Promise<string[]> {
 	try {
-		const content = await Bun.file(filePath).text();
+		const content = await getRuntime().fs.readFile(filePath);
 		// Simple YAML parsing for packages array
 		const packagesMatch = content.match(/packages:\s*\n((?:\s+-\s+.+\n?)+)/);
 		if (packagesMatch?.[1]) {
@@ -175,13 +177,13 @@ async function findWorkspacePackages(
 
 	for (const pattern of patterns) {
 		// Convert workspace pattern to glob for package.json files
-		const globPattern = pattern.includes("*")
-			? path.join(pattern, "package.json")
-			: path.join(pattern, "package.json");
+		const globPattern = path.join(pattern, "package.json");
 
 		try {
-			const glob = new Glob(globPattern);
-			for await (const match of glob.scan({ cwd: root, absolute: true })) {
+			for await (const match of getRuntime().glob.glob(globPattern, {
+				cwd: root,
+				absolute: true,
+			})) {
 				// Skip node_modules
 				if (match.includes("node_modules")) {
 					continue;
@@ -226,7 +228,7 @@ async function parsePackage(
 	let srcDir: string | undefined;
 	for (const candidate of ["src", "lib", "source"]) {
 		const candidatePath = path.join(pkgDir, candidate);
-		if (await fileExists(candidatePath)) {
+		if (await getRuntime().fs.exists(candidatePath)) {
 			srcDir = candidate;
 			break;
 		}
@@ -253,7 +255,7 @@ async function parsePackage(
 	let tsconfigPath: string | undefined;
 	for (const tsconfigName of ["tsconfig.json", "tsconfig.build.json"]) {
 		const candidatePath = path.join(pkgDir, tsconfigName);
-		if (await fileExists(candidatePath)) {
+		if (await getRuntime().fs.exists(candidatePath)) {
 			tsconfigPath = candidatePath;
 			break;
 		}
@@ -305,29 +307,10 @@ async function readPackageJson(
 	filePath: string
 ): Promise<Record<string, unknown> | null> {
 	try {
-		const content = await Bun.file(filePath).text();
+		const content = await getRuntime().fs.readFile(filePath);
 		return JSON.parse(content);
 	} catch {
 		return null;
-	}
-}
-
-/**
- * Check if a file or directory exists
- */
-async function fileExists(filePath: string): Promise<boolean> {
-	try {
-		const file = Bun.file(filePath);
-		// Bun.file().exists() works for files
-		if (await file.exists()) {
-			return true;
-		}
-		// For directories, we need to use stat
-		const { stat } = await import("node:fs/promises");
-		await stat(filePath);
-		return true;
-	} catch {
-		return false;
 	}
 }
 
@@ -336,11 +319,10 @@ async function fileExists(filePath: string): Promise<boolean> {
  */
 async function isBarrelFile(filePath: string): Promise<boolean> {
 	try {
-		const file = Bun.file(filePath);
-		if (!(await file.exists())) {
+		if (!(await getRuntime().fs.exists(filePath))) {
 			return false;
 		}
-		const content = await file.text();
+		const content = await getRuntime().fs.readFile(filePath);
 		// Check for export statements (export *, export {, export default, export const/function/class)
 		return EXPORT_STATEMENT_PATTERN.test(content);
 	} catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Public API for resect — runtime-agnostic TypeScript/JavaScript refactoring.
+ *
+ * Use `setRuntime(bunRuntime)` (default) or `setRuntime(nodeRuntime)` before
+ * calling any command that touches the filesystem.
+ */
+
+export type { MoveOptions } from "./commands/move.ts";
+// Commands
+export { moveCommand, moveModule } from "./commands/move.ts";
+export type {
+	RenameOptions,
+	RenameResult,
+} from "./commands/rename.ts";
+export {
+	renameCommand,
+	renameInSourceFile,
+	renameSymbol,
+} from "./commands/rename.ts";
+export { buildDependencyGraph } from "./core/graph.ts";
+// Core utilities
+export { loadProject, resolveTsConfig } from "./core/project.ts";
+export type { WorkspaceInfo, WorkspacePackage } from "./core/workspace.ts";
+export { discoverWorkspace } from "./core/workspace.ts";
+export type { FileSystem, GlobRunner, Runtime } from "./runtime/index.ts";
+// Runtime abstraction
+export {
+	bunRuntime,
+	getRuntime,
+	nodeRuntime,
+	setRuntime,
+} from "./runtime/index.ts";
+export type { ProjectConfig } from "./types.ts";

--- a/src/runtime/bun.ts
+++ b/src/runtime/bun.ts
@@ -1,0 +1,43 @@
+import { Glob } from "bun";
+import type { FileSystem, GlobRunner, Runtime } from "./types.ts";
+
+const bunFs: FileSystem = {
+	async readFile(path: string): Promise<string> {
+		return Bun.file(path).text();
+	},
+
+	async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+		await Bun.write(path, content);
+	},
+
+	async exists(path: string): Promise<boolean> {
+		const f = Bun.file(path);
+		if (await f.exists()) {
+			return true;
+		}
+		// Bun.file().exists() returns false for directories; fall back to stat
+		try {
+			const { stat } = await import("node:fs/promises");
+			await stat(path);
+			return true;
+		} catch {
+			return false;
+		}
+	},
+
+	async deleteFile(path: string): Promise<void> {
+		await Bun.file(path).delete();
+	},
+};
+
+const bunGlob: GlobRunner = {
+	glob(
+		pattern: string,
+		{ cwd, absolute }: { cwd: string; absolute?: boolean }
+	): AsyncIterable<string> {
+		const g = new Glob(pattern);
+		return g.scan({ cwd, absolute });
+	},
+};
+
+export const bunRuntime: Runtime = { fs: bunFs, glob: bunGlob };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,16 @@
+export { bunRuntime } from "./bun.ts";
+export { nodeRuntime } from "./node.ts";
+export type { FileSystem, GlobRunner, Runtime } from "./types.ts";
+
+import { bunRuntime } from "./bun.ts";
+import type { Runtime } from "./types.ts";
+
+let _runtime: Runtime = bunRuntime;
+
+export function getRuntime(): Runtime {
+	return _runtime;
+}
+
+export function setRuntime(runtime: Runtime): void {
+	_runtime = runtime;
+}

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { FileSystem, GlobRunner, Runtime } from "./types.ts";
+
+const nodeFs: FileSystem = {
+	async readFile(filePath: string): Promise<string> {
+		return fs.readFile(filePath, "utf-8");
+	},
+
+	async writeFile(
+		filePath: string,
+		content: string | Uint8Array
+	): Promise<void> {
+		await fs.writeFile(filePath, content);
+	},
+
+	async exists(filePath: string): Promise<boolean> {
+		try {
+			await fs.access(filePath);
+			return true;
+		} catch {
+			return false;
+		}
+	},
+
+	async deleteFile(filePath: string): Promise<void> {
+		await fs.unlink(filePath);
+	},
+};
+
+async function* globScan(
+	pattern: string,
+	{ cwd, absolute = false }: { cwd: string; absolute?: boolean }
+): AsyncGenerator<string> {
+	const parts = pattern.split("/");
+	yield* matchSegments(cwd, parts, 0, cwd, absolute);
+}
+
+async function* matchSegments(
+	basePath: string,
+	parts: string[],
+	depth: number,
+	cwd: string,
+	absolute: boolean
+): AsyncGenerator<string> {
+	const part = parts[depth];
+	if (part === undefined) {
+		return;
+	}
+	const isLast = depth === parts.length - 1;
+
+	if (part === "**") {
+		// Match zero or more segments
+		yield* matchSegments(basePath, parts, depth + 1, cwd, absolute);
+		try {
+			const entries = await fs.readdir(basePath, { withFileTypes: true });
+			for (const entry of entries) {
+				if (entry.isDirectory()) {
+					const nextPath = path.join(basePath, entry.name);
+					yield* matchSegments(nextPath, parts, depth, cwd, absolute);
+				}
+			}
+		} catch {
+			// Directory not readable; skip
+		}
+	} else if (part.includes("*")) {
+		const regex = new RegExp(`^${part.replace(/\*/g, "[^/]*")}$`);
+		try {
+			const entries = await fs.readdir(basePath, { withFileTypes: true });
+			for (const entry of entries) {
+				if (!regex.test(entry.name)) {
+					continue;
+				}
+				const nextPath = path.join(basePath, entry.name);
+				if (isLast) {
+					yield absolute ? nextPath : path.relative(cwd, nextPath);
+				} else if (entry.isDirectory()) {
+					yield* matchSegments(nextPath, parts, depth + 1, cwd, absolute);
+				}
+			}
+		} catch {
+			// Directory not readable; skip
+		}
+	} else {
+		const nextPath = path.join(basePath, part);
+		if (isLast) {
+			try {
+				await fs.access(nextPath);
+				yield absolute ? nextPath : path.relative(cwd, nextPath);
+			} catch {
+				// File not found; skip
+			}
+		} else {
+			yield* matchSegments(nextPath, parts, depth + 1, cwd, absolute);
+		}
+	}
+}
+
+const nodeGlob: GlobRunner = {
+	glob(
+		pattern: string,
+		options: { cwd: string; absolute?: boolean }
+	): AsyncIterable<string> {
+		return globScan(pattern, options);
+	},
+};
+
+export const nodeRuntime: Runtime = { fs: nodeFs, glob: nodeGlob };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,18 @@
+export interface FileSystem {
+	readFile(path: string): Promise<string>;
+	writeFile(path: string, content: string | Uint8Array): Promise<void>;
+	exists(path: string): Promise<boolean>;
+	deleteFile(path: string): Promise<void>;
+}
+
+export interface GlobRunner {
+	glob(
+		pattern: string,
+		options: { cwd: string; absolute?: boolean }
+	): AsyncIterable<string>;
+}
+
+export interface Runtime {
+	fs: FileSystem;
+	glob: GlobRunner;
+}


### PR DESCRIPTION
## Summary

- Add `src/runtime/` with `FileSystem` and `GlobRunner` interfaces and a `getRuntime()`/`setRuntime()` singleton
- Implement Bun adapter (`src/runtime/bun.ts`) wrapping `Bun.file()`, `Bun.write()`, `Glob`
- Implement Node.js adapter (`src/runtime/node.ts`) wrapping `node:fs/promises` with a recursive glob
- Replace all `Bun.*` calls in `move.ts`, `rename.ts`, and `workspace.ts` with `getRuntime().fs.*`
- Add `src/index.ts` public API with re-exports for commands, core utilities, and runtime
- Add `exports` map to `package.json` with `.`, `./bun`, `./node`, `./runtime` entry points
- Disable Biome `noBarrelFile` rule for entry-point files

## Test plan

- [x] `pnpm typecheck` passes (zero errors)
- [x] `pnpm lint` passes (Biome + ESLint clean)
- [x] `pnpm test` — all 133 tests pass