### PR TITLE
feat(workspace): add boundary enforcement filter

### DIFF
--- a/src/commands/alias.ts
+++ b/src/commands/alias.ts
@@ -15,7 +15,10 @@ import {
 	printVerificationResults,
 	verifyTypeChecking,
 } from "../core/verify.ts";
-import { discoverWorkspace } from "../core/workspace.ts";
+import {
+	discoverWorkspace,
+	filterToWorkspaceBoundary,
+} from "../core/workspace.ts";
 import { getRuntime } from "../runtime/index.ts";
 import type { ModuleReference, ProjectConfig } from "../types.ts";
 
@@ -81,7 +84,11 @@ export async function aliasCommand(options: AliasOptions): Promise<void> {
 				const pkgProject = loadProject(pkg.tsconfigPath);
 				const pkgDir = pkg.srcDir ? path.join(pkg.path, pkg.srcDir) : pkg.path;
 				const pkgResult = normalizeImports(pkgDir, prefer, pkgProject);
-				allChanges.push(...pkgResult.changes);
+				// Filter changes to workspace boundary
+				const bounded = pkgResult.changes.filter(
+					(c) => filterToWorkspaceBoundary([c.file], wsInfo.root).length > 0
+				);
+				allChanges.push(...bounded);
 				totalFiles += pkgResult.filesProcessed;
 			} catch {
 				if (verbose) {

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -17,7 +17,10 @@ import {
 	scanUnresolvableImports,
 } from "../core/scanner.ts";
 import { collectUnresolvableDiagnostics } from "../core/verify.ts";
-import { discoverWorkspace } from "../core/workspace.ts";
+import {
+	discoverWorkspace,
+	filterToWorkspaceBoundary,
+} from "../core/workspace.ts";
 import type {
 	AnalysisResult,
 	ModuleReference,
@@ -63,7 +66,12 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 					const pkgProject = loadProject(pkgTsconfig);
 					const pkgGraph = buildDependencyGraph(pkgProject);
 					const refs = findAllReferences(absolutePath, pkgGraph);
-					crossRefs.push(...refs);
+					// Filter refs to workspace boundary
+					const boundedRefs = refs.filter(
+						(r) =>
+							filterToWorkspaceBoundary([r.sourceFile], wsInfo.root).length > 0
+					);
+					crossRefs.push(...boundedRefs);
 				} catch {
 					// Skip packages that fail to load
 				}

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -3,7 +3,10 @@ import ts from "typescript";
 import { logger } from "../cli-logger.ts";
 import { scanExports } from "../core/scanner.ts";
 import { discoverProject } from "../core/tsconfig-discovery.ts";
-import { discoverWorkspace } from "../core/workspace.ts";
+import {
+	discoverWorkspace,
+	filterToWorkspaceBoundary,
+} from "../core/workspace.ts";
 import type { ExportInfo } from "../types.ts";
 
 export interface FindOptions {
@@ -55,7 +58,17 @@ export async function findCommand(options: FindOptions): Promise<void> {
 			}
 		}
 
-		const result = search(query, allFiles, absoluteProject, type);
+		// Filter to workspace boundary
+		const boundedPaths = filterToWorkspaceBoundary(
+			Array.from(allFiles.keys()),
+			wsInfo.root
+		);
+		const boundedFiles = new Map<string, unknown>();
+		for (const fp of boundedPaths) {
+			boundedFiles.set(fp, allFiles.get(fp));
+		}
+
+		const result = search(query, boundedFiles, absoluteProject, type);
 		printResults(result, absoluteProject, verbose);
 		return;
 	}

--- a/src/core/similarity.ts
+++ b/src/core/similarity.ts
@@ -354,7 +354,9 @@ export async function scanWorkspaceFunctions(directory: string): Promise<{
 	totalFiles: number;
 	packageCount: number;
 }> {
-	const { discoverWorkspace } = await import("./workspace.ts");
+	const { discoverWorkspace, filterToWorkspaceBoundary } = await import(
+		"./workspace.ts"
+	);
 	const workspace = await discoverWorkspace(path.resolve(directory));
 	if (!workspace || workspace.packages.length === 0) {
 		return { functions: [], totalFiles: 0, packageCount: 0 };
@@ -375,7 +377,8 @@ export async function scanWorkspaceFunctions(directory: string): Promise<{
 		}
 	}
 
-	const result = collectFunctionsFromFiles(allFiles);
+	const bounded = filterToWorkspaceBoundary(allFiles, workspace.root);
+	const result = collectFunctionsFromFiles(bounded);
 	return { ...result, packageCount: workspace.packages.length };
 }
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -417,6 +417,20 @@ function findMatchingExport(
 }
 
 /**
+ * Filter file paths to only include files within the workspace root boundary.
+ * Ensures that workspace-scoped operations do not leak outside the workspace.
+ */
+export function filterToWorkspaceBoundary(
+	filePaths: string[],
+	workspaceRoot: string
+): string[] {
+	const normalizedRoot = path.resolve(workspaceRoot) + path.sep;
+	return filePaths.filter(
+		(f) => f.startsWith(normalizedRoot) || f === path.resolve(workspaceRoot)
+	);
+}
+
+/**
  * Print workspace info to console
  */
 export function printWorkspaceInfo(workspace: WorkspaceInfo): void {


### PR DESCRIPTION
Add filterToWorkspaceBoundary utility to workspace.ts and apply it in similarity, find, analyze, and alias workspace paths. Ensures workspace-scoped operations only include files within the resolved workspace root.