### PR TITLE
feat(workspace): add input path boundary guards

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -56,6 +56,11 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 			: path.dirname(tsconfigPath);
 		const wsInfo = await discoverWorkspace(wsDir);
 		if (wsInfo && wsInfo.packages.length > 0) {
+			// Guard: reject if file is outside workspace root
+			if (filterToWorkspaceBoundary([absolutePath], wsInfo.root).length === 0) {
+				logger.error(`File is outside workspace root: ${wsInfo.root}`);
+				process.exit(1);
+			}
 			const crossRefs: ModuleReference[] = [];
 			for (const pkg of wsInfo.packages) {
 				const pkgTsconfig = pkg.tsconfigPath;

--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -5,7 +5,10 @@ import {
 	type ProjectDiscovery,
 	type TsConfigInfo,
 } from "../core/tsconfig-discovery.ts";
-import { discoverWorkspace } from "../core/workspace.ts";
+import {
+	discoverWorkspace,
+	filterToWorkspaceBoundary,
+} from "../core/workspace.ts";
 
 export interface DiscoverOptions {
 	directory: string;
@@ -21,6 +24,12 @@ export async function discoverCommand(options: DiscoverOptions): Promise<void> {
 		const wsInfo = await discoverWorkspace(absoluteDir);
 		if (!wsInfo || wsInfo.packages.length === 0) {
 			logger.error("No workspace packages found.");
+			process.exit(1);
+		}
+
+		// Guard: reject if directory is outside workspace root
+		if (filterToWorkspaceBoundary([absoluteDir], wsInfo.root).length === 0) {
+			logger.error(`Directory is outside workspace root: ${wsInfo.root}`);
 			process.exit(1);
 		}
 

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -45,6 +45,14 @@ export async function findCommand(options: FindOptions): Promise<void> {
 			process.exit(1);
 		}
 
+		// Guard: reject if project path is outside workspace root
+		if (
+			filterToWorkspaceBoundary([absoluteProject], wsInfo.root).length === 0
+		) {
+			logger.error(`Project path is outside workspace root: ${wsInfo.root}`);
+			process.exit(1);
+		}
+
 		logger.info(
 			`\n🔍 Searching for "${query}" across ${wsInfo.packages.length} workspace package(s)\n`
 		);

--- a/src/core/similarity.ts
+++ b/src/core/similarity.ts
@@ -357,8 +357,14 @@ export async function scanWorkspaceFunctions(directory: string): Promise<{
 	const { discoverWorkspace, filterToWorkspaceBoundary } = await import(
 		"./workspace.ts"
 	);
-	const workspace = await discoverWorkspace(path.resolve(directory));
+	const absDir = path.resolve(directory);
+	const workspace = await discoverWorkspace(absDir);
 	if (!workspace || workspace.packages.length === 0) {
+		return { functions: [], totalFiles: 0, packageCount: 0 };
+	}
+
+	// Guard: reject if directory is outside workspace root
+	if (filterToWorkspaceBoundary([absDir], workspace.root).length === 0) {
 		return { functions: [], totalFiles: 0, packageCount: 0 };
 	}
 


### PR DESCRIPTION
Add workspace boundary rejection guards to find, discover, analyze, and similar commands. Input paths outside the workspace root are now rejected with an error, matching the existing guard in the move command.