### PR TITLE
refactor(updater): use removeExtension for barrel exports

### DIFF
--- a/src/core/updater.test.ts
+++ b/src/core/updater.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { generateBarrelExport } from "./updater.ts";
+
+describe("generateBarrelExport", () => {
+	test("strips modern TS/JS extensions from barrel export specifier", () => {
+		const barrelPath = "/repo/packages/a/src/index.ts";
+		const barrelContent = 'export * from "./existing";\n';
+
+		const { exportStatement } = generateBarrelExport(
+			barrelContent,
+			"/repo/packages/a/src/foo.mts",
+			barrelPath
+		);
+		expect(exportStatement).toBe('export * from "./foo";\n');
+	});
+
+	test("strips .vue extension from barrel export specifier", () => {
+		const barrelPath = "/repo/packages/a/src/index.ts";
+		const barrelContent = "";
+
+		const { exportStatement } = generateBarrelExport(
+			barrelContent,
+			"/repo/packages/a/src/components/Thing.vue",
+			barrelPath
+		);
+		expect(exportStatement).toBe('export * from "./components/Thing";\n');
+	});
+});

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -5,6 +5,7 @@ import type { ExportInfo } from "../types/analysis.ts";
 import type { ImportBinding, ModuleReference } from "../types/graph.ts";
 import type { UpdatedReference } from "../types/move.ts";
 import type { ProjectConfig } from "../types.ts";
+import { removeExtension } from "./constants.ts";
 import {
 	calculateNewSpecifier,
 	findCrossPackageImport,
@@ -655,7 +656,7 @@ export function generateBarrelExport(
 	// Calculate relative path from barrel to target
 	const barrelDir = path.dirname(barrelPath);
 	let relativePath = path.relative(barrelDir, targetPath);
-	relativePath = relativePath.replace(/\.[tj]sx?$/, ""); // Remove extension
+	relativePath = removeExtension(relativePath);
 	if (!relativePath.startsWith(".")) {
 		relativePath = `./${relativePath}`;
 	}


### PR DESCRIPTION
## Summary
- Use shared `removeExtension()` for barrel export generation.
- Add tests covering `.mts` and `.vue` targets.

## Test plan
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`

Fixes #51