### PR TITLE
fix(rename): rename in-file references by symbol

### DIFF
--- a/src/commands/extract-common.test.ts
+++ b/src/commands/extract-common.test.ts
@@ -50,18 +50,20 @@ export function otherB(): number {
 	);
 }
 
-function captureStdout(): { output: () => string; restore: () => void } {
-	const originalWrite = process.stdout.write.bind(process.stdout);
-	let buf = "";
-	process.stdout.write = (chunk: string | Uint8Array) => {
-		buf += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
-		return true;
-	};
+function runExtractCommonCli(args: string[]): {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+} {
+	const proc = Bun.spawnSync(
+		["bun", path.join(process.cwd(), "src/cli.ts"), "extract-common", ...args],
+		{ stdout: "pipe", stderr: "pipe" }
+	);
+
 	return {
-		output: () => buf,
-		restore: () => {
-			process.stdout.write = originalWrite;
-		},
+		stdout: proc.stdout.toString(),
+		stderr: proc.stderr.toString(),
+		exitCode: proc.exitCode,
 	};
 }
 
@@ -69,23 +71,17 @@ describe("extract-common", () => {
 	test("dry-run reports duplicates without modifying files", async () => {
 		const dir = nextFixtureDir();
 		await setupFixtures(dir);
-		const cap = captureStdout();
 
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: true,
-			});
-		} finally {
-			cap.restore();
-		}
-
-		const output = cap.output();
-		expect(output).toContain("Dry run");
-		expect(output).toContain("formatDate");
-		expect(output).toContain("Would remove from");
+		const { stdout, stderr, exitCode } = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--dry-run",
+			"--force",
+		]);
+		expect(exitCode).toBe(0);
+		expect(stdout + stderr).toContain("Dry run");
+		expect(stdout + stderr).toContain("formatDate");
+		expect(stdout + stderr).toContain("Would remove from");
 
 		// Files should be unchanged
 		const aContent = await Bun.file(path.join(dir, "a.ts")).text();
@@ -157,19 +153,14 @@ describe("extract-common", () => {
 `
 		);
 
-		const cap = captureStdout();
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: true,
-			});
-		} finally {
-			cap.restore();
-		}
-
-		expect(cap.output()).toContain("No similar function groups found");
+		const { stdout, stderr, exitCode } = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--dry-run",
+			"--force",
+		]);
+		expect(exitCode).toBe(0);
+		expect(stdout + stderr).toContain("No similar function groups found");
 
 		await rm(dir, { recursive: true, force: true });
 	});
@@ -457,18 +448,13 @@ export const contactsRegistry = { reAuth: async () => {} };
 `
 		);
 
-		const cap = captureStdout();
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: false,
-				sameNameOnly: true,
-			});
-		} finally {
-			cap.restore();
-		}
+		await extractCommonCommand({
+			directory: dir,
+			threshold: 0.95,
+			force: true,
+			dryRun: false,
+			sameNameOnly: true,
+		});
 
 		const calContent = await Bun.file(path.join(dir, "cal.ts")).text();
 		const contactsContent = await Bun.file(
@@ -523,24 +509,17 @@ export const contactsRegistry = { reAuth: async () => {} };
 	test("--json emits valid JSON with expected schema", async () => {
 		const dir = nextFixtureDir();
 		await setupFixtures(dir);
-		const cap = captureStdout();
-		let output = "";
-
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: true,
-				json: true,
-			});
-		} finally {
-			cap.restore();
-			output = cap.output();
-		}
+		const { stdout, exitCode } = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--dry-run",
+			"--force",
+			"--json",
+		]);
+		expect(exitCode).toBe(0);
 
 		// Should be valid JSON
-		const parsed = JSON.parse(output);
+		const parsed = JSON.parse(stdout);
 
 		// Top-level schema
 		expect(typeof parsed.totalGroups).toBe("number");
@@ -583,23 +562,15 @@ export const contactsRegistry = { reAuth: async () => {} };
 	test("--json without --dry-run modifies files and emits JSON with dryRun: false", async () => {
 		const dir = nextFixtureDir();
 		await setupFixtures(dir);
-		const cap = captureStdout();
-		let output = "";
+		const { stdout, exitCode } = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--force",
+			"--json",
+		]);
+		expect(exitCode).toBe(0);
 
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: false,
-				json: true,
-			});
-		} finally {
-			cap.restore();
-			output = cap.output();
-		}
-
-		const parsed = JSON.parse(output);
+		const parsed = JSON.parse(stdout);
 		expect(parsed.dryRun).toBe(false);
 		expect(parsed.totalGroups).toBeGreaterThan(0);
 
@@ -615,27 +586,15 @@ export const contactsRegistry = { reAuth: async () => {} };
 		const dir = nextFixtureDir();
 		await setupFixtures(dir);
 
-		let exitCode: number | undefined;
-		const originalExit = process.exit.bind(process);
-		process.exit = ((code?: number) => {
-			exitCode = code ?? 0;
-		}) as typeof process.exit;
+		const result = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--dry-run",
+			"--force",
+			"--strict",
+		]);
+		expect(result.exitCode).toBe(1);
 
-		const cap = captureStdout();
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: true,
-				strict: true,
-			});
-		} finally {
-			cap.restore();
-			process.exit = originalExit;
-		}
-
-		expect(exitCode).toBe(1);
 		// Files should be unchanged (dry-run)
 		const bContent = await Bun.file(path.join(dir, "b.ts")).text();
 		expect(bContent).toContain("function formatDate");
@@ -658,25 +617,14 @@ export const contactsRegistry = { reAuth: async () => {} };
 			"export function onlyHere(): number { return 1; }\n"
 		);
 
-		let exitCode: number | undefined;
-		const originalExit = process.exit.bind(process);
-		process.exit = ((code?: number) => {
-			exitCode = code ?? 0;
-		}) as typeof process.exit;
-
-		try {
-			await extractCommonCommand({
-				directory: dir,
-				threshold: 0.95,
-				force: true,
-				dryRun: true,
-				strict: true,
-			});
-		} finally {
-			process.exit = originalExit;
-		}
-
-		expect(exitCode).toBeUndefined();
+		const result = runExtractCommonCli([
+			dir,
+			"--threshold=0.95",
+			"--dry-run",
+			"--force",
+			"--strict",
+		]);
+		expect(result.exitCode).toBe(0);
 
 		await rm(dir, { recursive: true, force: true });
 	});

--- a/src/commands/rename.test.ts
+++ b/src/commands/rename.test.ts
@@ -2,13 +2,74 @@ import { describe, expect, test } from "bun:test";
 import ts from "typescript";
 import { renameInSourceFile } from "./rename";
 
-function parse(source: string): ts.SourceFile {
-	return ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+function buildProgram(source: string): {
+	program: ts.Program;
+	sourceFile: ts.SourceFile;
+} {
+	const fileName = "/virtual/test.ts";
+	const options: ts.CompilerOptions = { target: ts.ScriptTarget.ESNext };
+	const host = ts.createCompilerHost(options, true);
+	host.getSourceFile = (name, languageVersion) => {
+		if (name === fileName) {
+			return ts.createSourceFile(name, source, languageVersion, true);
+		}
+		return undefined;
+	};
+	host.readFile = (name) => (name === fileName ? source : undefined);
+	host.fileExists = (name) => name === fileName;
+	host.writeFile = () => undefined;
+
+	const program = ts.createProgram([fileName], options, host);
+	const sourceFile = program.getSourceFile(fileName);
+	if (!sourceFile) {
+		throw new Error("Failed to create source file");
+	}
+	return { program, sourceFile };
+}
+
+function getExportedSymbol(
+	sourceFile: ts.SourceFile,
+	checker: ts.TypeChecker,
+	name: string
+): ts.Symbol | null {
+	let found: ts.Symbol | null = null;
+	const visit = (node: ts.Node) => {
+		if (found) {
+			return;
+		}
+		if (
+			ts.isFunctionDeclaration(node) &&
+			node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) &&
+			node.name?.text === name
+		) {
+			found = checker.getSymbolAtLocation(node.name) ?? null;
+			return;
+		}
+		if (
+			ts.isVariableStatement(node) &&
+			node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+		) {
+			for (const decl of node.declarationList.declarations) {
+				if (ts.isIdentifier(decl.name) && decl.name.text === name) {
+					found = checker.getSymbolAtLocation(decl.name) ?? null;
+					return;
+				}
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return found;
 }
 
 function rename(source: string, oldName: string, newName: string): string {
-	const sf = parse(source);
-	return renameInSourceFile(sf, oldName, newName).newContent;
+	const { program, sourceFile } = buildProgram(source);
+	const checker = program.getTypeChecker();
+	const renamedSymbol = getExportedSymbol(sourceFile, checker, oldName);
+	return renameInSourceFile(sourceFile, oldName, newName, {
+		checker,
+		renamedSymbol: renamedSymbol ?? undefined,
+	}).newContent;
 }
 
 describe("renameInSourceFile — shadowing", () => {
@@ -95,5 +156,12 @@ describe("renameInSourceFile — shadowing", () => {
 		expect(result).toContain("export const baz = 1");
 		// inner declaration left unchanged
 		expect(result).toContain("const foo = 2");
+	});
+
+	test("renames shorthand object properties that reference the export", () => {
+		const src = ["export const foo = 1;", "const obj = { foo };"].join("\n");
+		const result = rename(src, "foo", "bar");
+		expect(result).toContain("export const bar = 1");
+		expect(result).toContain("const obj = { bar }");
 	});
 });

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { logger, printCommandResult } from "../cli-logger.ts";
 import ts from "../core/ast-utils.ts";
+import { mapConcurrent } from "../core/concurrency.ts";
 import { checkAllConflicts } from "../core/conflict-detection.ts";
 import { ensureCleanWorktree } from "../core/git.ts";
 import { buildDependencyGraph, findAllReferences } from "../core/graph.ts";
@@ -68,7 +69,6 @@ export async function renameCommand(options: RenameOptions): Promise<void> {
 			: path.dirname(tsconfigPath);
 		const wsInfo = await discoverWorkspace(wsDir);
 		if (wsInfo && wsInfo.packages.length > 0) {
-			const { mapConcurrent } = await import("../core/concurrency.ts");
 			const eligiblePkgs = wsInfo.packages.filter(
 				(pkg) => pkg.tsconfigPath && pkg.tsconfigPath !== tsconfigPath
 			);
@@ -159,6 +159,7 @@ export async function renameSymbol(
 
 	// Create program for parsing
 	const program = createProgram(project);
+	const checker = program.getTypeChecker();
 
 	// First, rename the export in the source file
 	const sourceAst = program.getSourceFile(filePath);
@@ -232,7 +233,11 @@ export async function renameSymbol(
 	}
 
 	// Rename in source file
-	const sourceResult = renameInSourceFile(sourceAst, oldName, newName);
+	const renamedSymbol = getRenamedSymbol(sourceAst, checker, exportInfo);
+	const sourceResult = renameInSourceFile(sourceAst, oldName, newName, {
+		checker,
+		renamedSymbol: renamedSymbol ?? undefined,
+	});
 	if (sourceResult.changes.length > 0) {
 		updatedReferences.push(
 			...sourceResult.updates.map((u) => ({ ...u, file: filePath }))
@@ -296,6 +301,41 @@ interface ExportLocation {
 	type: "declaration" | "named-export" | "default";
 	node: ts.Node;
 	line: number;
+}
+
+function getRenamedSymbol(
+	_sourceFile: ts.SourceFile,
+	checker: ts.TypeChecker,
+	location: ExportLocation
+): ts.Symbol | null {
+	if (location.type === "declaration") {
+		const nameNode = getNameNode(location.node);
+		if (nameNode) {
+			return checker.getSymbolAtLocation(nameNode) ?? null;
+		}
+		return null;
+	}
+
+	if (location.type === "default") {
+		if (
+			ts.isExportAssignment(location.node) &&
+			!location.node.isExportEquals &&
+			ts.isIdentifier(location.node.expression)
+		) {
+			return checker.getSymbolAtLocation(location.node.expression) ?? null;
+		}
+		return null;
+	}
+
+	// named-export: export { foo } / export { foo as Bar }
+	// Prefer the local name (propertyName when present, else name).
+	if (ts.isExportSpecifier(location.node)) {
+		const localId = location.node.propertyName ?? location.node.name;
+		return checker.getSymbolAtLocation(localId) ?? null;
+	}
+
+	// Fallback — keep behavior unchanged if we can't resolve a symbol
+	return null;
 }
 
 function findExport(
@@ -369,7 +409,11 @@ function findExport(
 export function renameInSourceFile(
 	sourceFile: ts.SourceFile,
 	oldName: string,
-	newName: string
+	newName: string,
+	options?: {
+		checker?: ts.TypeChecker;
+		renamedSymbol?: ts.Symbol;
+	}
 ): {
 	newContent: string;
 	changes: TextChange[];
@@ -377,6 +421,8 @@ export function renameInSourceFile(
 } {
 	const changes: TextChange[] = [];
 	const updates: Omit<UpdatedReference, "file">[] = [];
+	const checker = options?.checker;
+	const renamedSymbol = options?.renamedSymbol;
 
 	// Returns true if a binding pattern (parameter name, destructuring) introduces `name`
 	function bindingContainsName(binding: ts.BindingName): boolean {
@@ -517,36 +563,56 @@ export function renameInSourceFile(
 			});
 		}
 
-		// Also rename usages within the file itself
+		// Also rename usages within the file itself.
+		//
+		// When a TypeChecker + symbol is provided, use symbol identity to ensure we only
+		// rename true references to the exported symbol (avoids false positives).
+		// Fallback to the existing heuristic when no checker is available (unit tests,
+		// standalone SourceFile parsing).
 		if (ts.isIdentifier(node) && node.text === oldName) {
-			// Skip if this is a property access (obj.oldName)
-			if (
-				node.parent &&
-				ts.isPropertyAccessExpression(node.parent) &&
-				node.parent.name === node
-			) {
-				// This is accessing a property, not our symbol
-				return;
-			}
-			// Skip if this is a property in an object literal
-			if (
-				node.parent &&
-				ts.isPropertyAssignment(node.parent) &&
-				node.parent.name === node
-			) {
-				return;
-			}
-			// Skip import specifiers (handled separately)
-			if (
-				node.parent &&
-				(ts.isImportSpecifier(node.parent) || ts.isExportSpecifier(node.parent))
-			) {
-				return;
-			}
-			// Skip if this identifier is declaring a new binding in an inner scope
-			// (parameter name, variable declaration, destructuring element, inner function/class name)
-			if (isDeclaringIdentifier(node)) {
-				return;
+			if (checker && renamedSymbol) {
+				let symbolAtNode = checker.getSymbolAtLocation(node);
+
+				// Shorthand property assignments (`{ foo }`) are represented as a property,
+				// but semantically refer to the value symbol of `foo`.
+				if (
+					symbolAtNode !== renamedSymbol &&
+					ts.isShorthandPropertyAssignment(node.parent) &&
+					node.parent.name === node
+				) {
+					symbolAtNode =
+						checker.getShorthandAssignmentValueSymbol(node.parent) ??
+						symbolAtNode;
+				}
+
+				if (symbolAtNode !== renamedSymbol) {
+					ts.forEachChild(node, (child) => visit(child, false));
+					return;
+				}
+			} else {
+				// Heuristic fallback (best-effort without binder)
+				// Skip if this is a property access (obj.oldName)
+				if (
+					node.parent &&
+					ts.isPropertyAccessExpression(node.parent) &&
+					node.parent.name === node
+				) {
+					// This is accessing a property, not our symbol
+					return;
+				}
+				// Skip import/export specifiers (handled separately)
+				if (
+					node.parent &&
+					(ts.isImportSpecifier(node.parent) ||
+						ts.isExportSpecifier(node.parent))
+				) {
+					return;
+				}
+				// Skip if this identifier is declaring a new binding in an inner scope
+				// (parameter name, variable declaration, destructuring element, inner function/class name)
+				if (isDeclaringIdentifier(node)) {
+					return;
+				}
 			}
 
 			const { line } = sourceFile.getLineAndCharacterOfPosition(


### PR DESCRIPTION
## Summary
- Use `ts.TypeChecker` symbol identity for in-file renames to avoid false positives.
- Make `extract-common` tests safe under `bun test --concurrent` by using CLI subprocesses (no global stdout/process.exit patching).

## Test plan
- bun run typecheck
- bun run lint
- bun test --concurrent

Fixes #49