### PR TITLE
fix(updater): detect barrel consumers by specifier resolution

### DIFF
--- a/src/core/updater.test.ts
+++ b/src/core/updater.test.ts
@@ -1,5 +1,92 @@
-import { describe, expect, test } from "bun:test";
-import { generateBarrelExport } from "./updater.ts";
+import { afterEach, describe, expect, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+import type { ExportInfo } from "../types/analysis.ts";
+import type { ModuleReference } from "../types/graph.ts";
+import type { ProjectConfig } from "../types.ts";
+import { generateBarrelExport, updateFileReferences } from "./updater.ts";
+import type { WorkspaceInfo } from "./workspace.ts";
+
+let fixtureCounter = 0;
+function nextDir(): string {
+	fixtureCounter++;
+	return path.join(
+		import.meta.dir,
+		"../commands/__fixtures__",
+		`updater-${fixtureCounter}-${Date.now()}`
+	);
+}
+
+async function writeFixture(dir: string, relPath: string, content: string) {
+	const abs = path.join(dir, relPath);
+	await Bun.write(abs, content);
+	return abs;
+}
+
+async function makeProject(dir: string): Promise<ProjectConfig> {
+	const tsconfigPath = await writeFixture(
+		dir,
+		"tsconfig.json",
+		JSON.stringify({
+			compilerOptions: {
+				target: "ES2020",
+				module: "ESNext",
+				moduleResolution: "NodeNext",
+				strict: true,
+			},
+			include: ["**/*.ts"],
+		})
+	);
+
+	// Minimal ProjectConfig for resolver: we only rely on compilerOptions/rootDir.
+	return {
+		rootDir: dir,
+		tsconfigPath,
+		compilerOptions: {
+			target: ts.ScriptTarget.ES2020,
+			module: ts.ModuleKind.ESNext,
+			moduleResolution: ts.ModuleResolutionKind.NodeNext,
+			strict: true,
+		},
+		pathAliases: new Map(),
+		include: ["**/*.ts"],
+		exclude: [],
+		files: [],
+	};
+}
+
+function makeWorkspace(dir: string): WorkspaceInfo {
+	return {
+		root: dir,
+		type: "unknown",
+		patterns: [],
+		packages: [
+			{
+				name: "@scope/pkg-a",
+				path: path.join(dir, "packages", "pkg-a"),
+				packageJsonPath: path.join(dir, "packages", "pkg-a", "package.json"),
+				srcDir: "src",
+			},
+			{
+				name: "@scope/pkg-b",
+				path: path.join(dir, "packages", "pkg-b"),
+				packageJsonPath: path.join(dir, "packages", "pkg-b", "package.json"),
+				srcDir: "src",
+			},
+		],
+	};
+}
+
+afterEach(async () => {
+	// Best-effort cleanup of any updater fixtures we created under __fixtures__
+	const fixturesDir = path.join(import.meta.dir, "../commands/__fixtures__");
+	const glob = new Bun.Glob("updater-*");
+	for await (const match of glob.scan({ cwd: fixturesDir, onlyFiles: false })) {
+		const abs = path.join(fixturesDir, match);
+		await rm(abs, { recursive: true, force: true });
+	}
+});
 
 describe("generateBarrelExport", () => {
 	test("strips modern TS/JS extensions from barrel export specifier", () => {
@@ -24,5 +111,171 @@ describe("generateBarrelExport", () => {
 			barrelPath
 		);
 		expect(exportStatement).toBe('export * from "./components/Thing";\n');
+	});
+});
+
+describe("updateFileReferences — barrel reference detection", () => {
+	test("does not treat direct imports as barrel references", async () => {
+		const dir = nextDir();
+		await writeFixture(
+			dir,
+			"packages/pkg-a/package.json",
+			JSON.stringify({ name: "@scope/pkg-a" })
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-b/package.json",
+			JSON.stringify({ name: "@scope/pkg-b" })
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-a/src/moved.ts",
+			"export const a = 1; export const c = 2;\n"
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-a/src/barrel.ts",
+			'export * from "./moved";\n'
+		);
+		const consumerPath = await writeFixture(
+			dir,
+			"packages/pkg-a/src/consumer.ts",
+			'import { a, c } from "./moved";\n'
+		);
+
+		const project = await makeProject(dir);
+		project.files = [
+			consumerPath,
+			path.join(dir, "packages/pkg-a/src/barrel.ts"),
+			path.join(dir, "packages/pkg-a/src/moved.ts"),
+		];
+		const program = ts.createProgram(project.files, project.compilerOptions);
+		const consumerSf = program.getSourceFile(consumerPath);
+		expect(consumerSf).toBeTruthy();
+		if (!consumerSf) {
+			return;
+		}
+
+		const oldPath = path.join(dir, "packages/pkg-a/src/moved.ts");
+		const newPath = path.join(dir, "packages/pkg-b/src/moved.ts");
+		const refs: ModuleReference[] = [
+			{
+				sourceFile: consumerPath,
+				specifier: "./moved",
+				resolvedPath: oldPath,
+				type: "import-named",
+				line: 1,
+				column: 1,
+				bindings: [
+					{ name: "a", isType: false },
+					{ name: "c", isType: false },
+				],
+				isTypeOnly: false,
+			},
+		];
+
+		const movedFileExports: ExportInfo[] = [
+			{ name: "a", type: "named", isType: false, line: 1 },
+			{ name: "c", type: "named", isType: false, line: 1 },
+		];
+
+		const { newContent } = updateFileReferences(
+			consumerSf,
+			refs,
+			oldPath,
+			newPath,
+			project,
+			makeWorkspace(dir),
+			movedFileExports
+		);
+
+		// Should remain a single import (specifier updated), no split into two statements.
+		expect(newContent.split("\n").filter(Boolean).length).toBe(1);
+	});
+
+	test("splits barrel imports when only some bindings come from moved file", async () => {
+		const dir = nextDir();
+		await writeFixture(
+			dir,
+			"packages/pkg-a/package.json",
+			JSON.stringify({ name: "@scope/pkg-a" })
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-b/package.json",
+			JSON.stringify({ name: "@scope/pkg-b" })
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-a/src/moved.ts",
+			"export const a = 1;\n"
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-a/src/other.ts",
+			"export const c = 2;\n"
+		);
+		await writeFixture(
+			dir,
+			"packages/pkg-a/src/barrel.ts",
+			['export { a } from "./moved";', 'export { c } from "./other";', ""].join(
+				"\n"
+			)
+		);
+		const consumerPath = await writeFixture(
+			dir,
+			"packages/pkg-a/src/consumer.ts",
+			'import { a, c } from "./barrel";\n'
+		);
+
+		const project = await makeProject(dir);
+		project.files = [
+			consumerPath,
+			path.join(dir, "packages/pkg-a/src/barrel.ts"),
+			path.join(dir, "packages/pkg-a/src/moved.ts"),
+			path.join(dir, "packages/pkg-a/src/other.ts"),
+		];
+		const program = ts.createProgram(project.files, project.compilerOptions);
+		const consumerSf = program.getSourceFile(consumerPath);
+		expect(consumerSf).toBeTruthy();
+		if (!consumerSf) {
+			return;
+		}
+
+		const oldPath = path.join(dir, "packages/pkg-a/src/moved.ts");
+		const newPath = path.join(dir, "packages/pkg-b/src/moved.ts");
+		const refs: ModuleReference[] = [
+			{
+				sourceFile: consumerPath,
+				specifier: "./barrel",
+				resolvedPath: oldPath, // effective target rewritten by findAllReferences
+				type: "import-named",
+				line: 1,
+				column: 1,
+				bindings: [
+					{ name: "a", isType: false },
+					{ name: "c", isType: false },
+				],
+				isTypeOnly: false,
+			},
+		];
+
+		const movedFileExports: ExportInfo[] = [
+			{ name: "a", type: "named", isType: false, line: 1 },
+		];
+
+		const { newContent } = updateFileReferences(
+			consumerSf,
+			refs,
+			oldPath,
+			newPath,
+			project,
+			makeWorkspace(dir),
+			movedFileExports
+		);
+
+		// Should be split into two statements.
+		expect(newContent).toContain('from "@scope/pkg-b"');
+		expect(newContent).toContain('from "./barrel"');
 	});
 });

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -62,15 +62,31 @@ export function updateFileReferences(
 	const movedExportNames = new Set(movedFileExports?.map((e) => e.name) ?? []);
 
 	for (const ref of references) {
-		// Check if this is an indirect reference through a barrel
-		// (reference specifier doesn't directly point to the moved file)
+		// Check if this is an indirect reference through a barrel.
+		//
+		// `findAllReferences()` may rewrite `ref.resolvedPath` to the moved module even
+		// when the specifier points to a barrel. Therefore we must distinguish:
+		// - direct import: ref.specifier resolves to oldPath
+		// - barrel consumer: ref.specifier resolves elsewhere, but effective resolvedPath is oldPath
+		const effectiveTargetsMovedFile =
+			normalizePath(ref.resolvedPath) === normalizePath(oldPath);
+		const specifierResolution = resolveModuleSpecifier(
+			ref.specifier,
+			ref.sourceFile,
+			project
+		);
+		const specifierDirectlyTargetsMovedFile =
+			specifierResolution.kind === "resolved" &&
+			normalizePath(specifierResolution.path) === normalizePath(oldPath);
+
 		const isBarrelReference =
 			crossPackage &&
 			movedFileExports &&
 			movedFileExports.length > 0 &&
 			ref.bindings &&
 			ref.bindings.length > 0 &&
-			normalizePath(ref.resolvedPath) === normalizePath(oldPath);
+			effectiveTargetsMovedFile &&
+			!specifierDirectlyTargetsMovedFile;
 
 		// For barrel references with mixed bindings, we need to split the import
 		if (isBarrelReference && ref.bindings) {


### PR DESCRIPTION
## Summary
- Fix barrel-consumer detection in `updateFileReferences()` by resolving the original specifier.
- Add regression tests covering direct-import vs barrel-consumer behavior.

## Test plan
- bun run typecheck
- bun run lint
- bun test --concurrent

Fixes #48