### PR TITLE
fix(move): preserve quote style in barrel insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable user-facing changes to this project are documented here.
   when analyzing projects outside the working directory. Paths are now
   relative to the tsconfig project root.
 
+- **Barrel insertion now preserves quote style and extension conventions**:
+  When `move` adds `export *` to a destination barrel, it now matches
+  the existing file's quote style (single vs double) and extension
+  usage (`.ts` vs extensionless).
+
 ## [1.5.0] - 2026-03-28
 
 ### New Features

--- a/src/core/updater.test.ts
+++ b/src/core/updater.test.ts
@@ -119,7 +119,44 @@ describe("generateBarrelExport", () => {
 			"/repo/packages/a/src/components/Thing.vue",
 			barrelPath
 		);
-		expect(exportStatement).toBe('export * from "./components/Thing";\n');
+		// Empty barrel defaults to single quotes
+		expect(exportStatement).toBe("export * from './components/Thing';\n");
+	});
+
+	test("matches existing double-quote style", () => {
+		const barrelPath = "/repo/packages/a/src/index.ts";
+		const barrelContent = 'export * from "./existing";\n';
+
+		const { exportStatement } = generateBarrelExport(
+			barrelContent,
+			"/repo/packages/a/src/foo.ts",
+			barrelPath
+		);
+		expect(exportStatement).toBe('export * from "./foo";\n');
+	});
+
+	test("matches existing single-quote style", () => {
+		const barrelPath = "/repo/packages/a/src/index.ts";
+		const barrelContent = "export * from './existing';\n";
+
+		const { exportStatement } = generateBarrelExport(
+			barrelContent,
+			"/repo/packages/a/src/bar.ts",
+			barrelPath
+		);
+		expect(exportStatement).toBe("export * from './bar';\n");
+	});
+
+	test("preserves extension when existing barrel uses extensions", () => {
+		const barrelPath = "/repo/packages/a/src/index.ts";
+		const barrelContent = "export * from './existing.ts';\n";
+
+		const { exportStatement } = generateBarrelExport(
+			barrelContent,
+			"/repo/packages/a/src/foo.ts",
+			barrelPath
+		);
+		expect(exportStatement).toBe("export * from './foo.ts';\n");
 	});
 });
 

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -5,7 +5,7 @@ import type { ExportInfo } from "../types/analysis.ts";
 import type { ImportBinding, ModuleReference } from "../types/graph.ts";
 import type { UpdatedReference } from "../types/move.ts";
 import type { ProjectConfig } from "../types.ts";
-import { removeExtension } from "./constants.ts";
+import { removeExtension, TS_JS_VUE_EXTENSIONS } from "./constants.ts";
 import {
 	calculateNewSpecifier,
 	findCrossPackageImport,
@@ -672,13 +672,25 @@ export function generateBarrelExport(
 	// Calculate relative path from barrel to target
 	const barrelDir = path.dirname(barrelPath);
 	let relativePath = path.relative(barrelDir, targetPath);
-	relativePath = removeExtension(relativePath);
+
+	// Detect existing barrel style: quote character and extension usage
+	const quoteMatch = barrelContent.match(/from\s+(['"])/);
+	const quote = quoteMatch?.[1] ?? "'";
+	const specifierMatches = [
+		...barrelContent.matchAll(/from\s+['"]([^'"]+)['"]/g),
+	];
+	const usesExtensions = specifierMatches.some(
+		(m) => m[1] && TS_JS_VUE_EXTENSIONS.test(m[1])
+	);
+
+	if (!usesExtensions) {
+		relativePath = removeExtension(relativePath);
+	}
 	if (!relativePath.startsWith(".")) {
 		relativePath = `./${relativePath}`;
 	}
 
-	// Use star export as default style
-	const exportStatement = `export * from "${relativePath}";\n`;
+	const exportStatement = `export * from ${quote}${relativePath}${quote};\n`;
 
 	// Find insertion position - after the last export statement
 	const lines = barrelContent.split("\n");
@@ -723,8 +735,11 @@ export function addExportToDestinationBarrel(
 	);
 
 	// Check if this export already exists
-	const relativePath = exportStatement.match(/"([^"]+)"/)?.[1];
-	if (relativePath && barrelContent.includes(`from "${relativePath}"`)) {
+	const relativePath = exportStatement.match(/['"]([^'"]+)['"]/)?.[1];
+	if (
+		(relativePath && barrelContent.includes(`from '${relativePath}'`)) ||
+		(relativePath && barrelContent.includes(`from "${relativePath}"`))
+	) {
 		// Export already exists, no change needed
 		return {
 			newContent: barrelContent,


### PR DESCRIPTION
## Summary

When the `move` command adds `export *` to a destination barrel file during cross-package moves, it now matches the existing file's conventions:

- **Quote style**: detects whether the barrel uses single or double quotes and matches
- **Extension usage**: if existing exports use `.ts` extensions, the new export keeps the extension; if extensionless, the extension is stripped

Previously, barrel insertions always used double quotes and stripped extensions, creating style inconsistencies in codebases that use single quotes or explicit `.ts` extensions (e.g. projects with `allowImportingTsExtensions`).

## Test plan

- [x] 3 new unit tests in `updater.test.ts`: double-quote matching, single-quote matching, extension preservation
- [x] 320 tests pass (317 existing + 3 new)
- [x] Typecheck and lint clean
- [x] E2E verified against TanStack Query monorepo (97 packages)