### PR TITLE
feat(move): add --prefer and preserve relative import style

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(bun run typecheck:*)",
       "Bash(bun test:*)",
       "Skill(update-memory)",
-      "Skill(commit)"
+      "Skill(commit)",
+      "Bash(gh issue *)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ resect move src/utils/old.ts src/helpers/new.ts --dry-run
 - Case-only renames on case-insensitive filesystems
 - Declarative AST rewrites via `--transform` (see [AST Transform Pipelines](#ast-transform-pipelines-move---transform))
 
+**Import style is preserved by default.** A relative import stays relative and an aliased import stays aliased, so a move never silently promotes `./locale` to `@/lib/i18n/locale`. That matters for code run by `node --experimental-strip-types`, which does not resolve tsconfig `paths`. Override per move with `--prefer`:
+
+```bash
+resect move lib/locale.ts lib/i18n/locale.ts --prefer=relative  # force relative paths
+resect move src/a.ts src/nested/a.ts --prefer=alias             # force tsconfig aliases
+resect move src/a.ts src/nested/a.ts --prefer=shortest          # pick whichever is shorter
+```
+
+Cross-package moves are unaffected — they still resolve to the destination package's import specifier.
+
 ### `rename <file> <oldName> <newName>`
 
 Rename an exported symbol and update all imports.
@@ -619,7 +629,7 @@ Under Bun the default runtime works out of the box; subpath entry points `@mhero
 | `--fix` | | Apply suggested fixes (mock-cleanup, test-relocation, naming, tidy) |
 | `--transform` | | Apply AST rewrites from a config during a move; takes a value: `--transform=.resect/transforms.js` |
 | `--type` | `-t` | Filter find results by type: `file`, `export`, or `all` |
-| `--prefer` | | Alias strategy: `alias`, `relative`, or `shortest` |
+| `--prefer` | | Import-specifier strategy: `alias`, `relative`, or `shortest`. Required by `alias`; optional on `move`, where omitting it preserves each importer's existing style |
 | `--rename-specifier` | | Exact alias rewrite pair `<from>=<to>`; repeat for batch rewrites |
 | `--json` | | Output in JSON format (workspace/similar) |
 | `--threshold` | | Similarity threshold 0.0–1.0 (similar/extract-common) |

--- a/src/cli-logger.ts
+++ b/src/cli-logger.ts
@@ -1,8 +1,5 @@
 import path from "node:path";
-import {
-	formatUnifiedDiff,
-	type StructuredEdit,
-} from "./core/text-changes.ts";
+import { formatUnifiedDiff, type StructuredEdit } from "./core/text-changes.ts";
 
 /**
  * CLI Logger - Structured logging for user interface output

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,17 +4,12 @@ import { parseArgs } from "node:util";
 import { version } from "../package.json";
 import { logger } from "./cli-logger.ts";
 import { CLI_NAME, formatCommandList } from "./commands/command-spec.ts";
-import { PARSE_ARGS_OPTIONS } from "./commands/option-flags.ts";
+import { PARSE_ARGS_OPTIONS, preprocessArgs } from "./commands/option-flags.ts";
 import type { CliValues } from "./commands/registry.ts";
 import { COMMANDS } from "./commands/registry.ts";
 
 const cliArgs = Bun.argv.slice(2);
-const rawArgs = cliArgs.flatMap((arg) => {
-	if (cliArgs[0] === "tidy" && arg.startsWith("--fix=")) {
-		return ["--fix", "--fix-category", arg.slice("--fix=".length)];
-	}
-	return [arg];
-});
+const rawArgs = preprocessArgs(cliArgs);
 
 const { values, positionals } = parseArgs({
 	args: rawArgs,

--- a/src/commands/alias.ts
+++ b/src/commands/alias.ts
@@ -23,8 +23,8 @@ import {
 	createStructuredEdit,
 	deduplicateChanges,
 	formatUnifiedDiff,
-	serializeStructuredEdits,
 	type StructuredEdit,
+	serializeStructuredEdits,
 } from "../core/text-changes.ts";
 import { specifierEditsToTextChanges } from "../core/updater.ts";
 import {

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -68,10 +68,8 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 				const refs = findAllReferences(absolutePath, pkgGraph);
 				return refs.filter(
 					(r) =>
-						filterToWorkspaceBoundary(
-							[r.sourceFile],
-							workspaceInfo.root
-						).length > 0
+						filterToWorkspaceBoundary([r.sourceFile], workspaceInfo.root)
+							.length > 0
 				);
 			},
 			{ onError: () => [] }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { logger } from "../cli-logger.ts";
-import {
-	type DependencyGraph,
-	withGraphSourceFile,
-} from "../core/graph.ts";
+import { type DependencyGraph, withGraphSourceFile } from "../core/graph.ts";
 import { normalizePath } from "../core/resolver.ts";
 import { scanExports } from "../core/scanner.ts";
 import type { ReadOnlyCommandOptions } from "../types/commands.ts";

--- a/src/commands/barrel.ts
+++ b/src/commands/barrel.ts
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { logger } from "../cli-logger.ts";
-import {
-	type DependencyGraph,
-	withGraphSourceFile,
-} from "../core/graph.ts";
+import { type DependencyGraph, withGraphSourceFile } from "../core/graph.ts";
 import { loadProject } from "../core/project.ts";
 import { findSubpathExportForFile, normalizePath } from "../core/resolver.ts";
 import { scanBarrelExports } from "../core/scanner.ts";

--- a/src/commands/command-context.ts
+++ b/src/commands/command-context.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
+import { mapConcurrent } from "../core/concurrency.ts";
 import {
 	buildDependencyGraph,
 	buildProjectGraphs,
 	type DependencyGraph,
 	mergeDependencyGraphs,
 } from "../core/graph.ts";
-import { mapConcurrent } from "../core/concurrency.ts";
 import { loadProject, resolveTsConfig } from "../core/project.ts";
 import {
 	discoverWorkspace,
@@ -155,9 +155,7 @@ const mergeExtraProjectGraphs = async (
 					onError: () => null,
 				});
 	const availableGraphs = graphs.filter(
-		(
-			graph
-		): graph is { tsconfigPath: string; graph: DependencyGraph } =>
+		(graph): graph is { tsconfigPath: string; graph: DependencyGraph } =>
 			graph !== null
 	);
 	return {

--- a/src/commands/command-spec.ts
+++ b/src/commands/command-spec.ts
@@ -310,13 +310,18 @@ Options:
   --force           Allow operation when git worktree has uncommitted changes
   --verbose         Show detailed information about each change
   --workspace       Scan across all workspace packages
+  --prefer=STRATEGY Import style for rewritten specifiers: alias, relative, or
+                    shortest. Omit to keep each importer's existing style
+                    (relative stays relative, aliased stays aliased). Use
+                    relative for code run by node --experimental-strip-types,
+                    which does not resolve tsconfig paths
   --transform=PATH  Apply declarative AST rewrites from a config (e.g.
                     .resect/transforms.js) to the moved file; verified and
                     rolled back on new type errors
 
 Features:
   • Updates all import statements referencing the moved file
-  • Preserves path aliases when possible
+  • Preserves each importer's existing specifier style by default
   • Updates barrel file re-exports
   • Handles dynamic imports and require() calls
   • Updates internal imports within the moved file
@@ -325,10 +330,11 @@ Features:
 Examples:
   ${CLI_NAME} move src/utils/old.ts src/helpers/new.ts
   ${CLI_NAME} move src/components/Button.tsx src/ui/Button.tsx --dry-run
+  ${CLI_NAME} move lib/locale.ts lib/i18n/locale.ts --prefer=relative
   ${CLI_NAME} move src/config.ts packages/shared/src/config.ts --transform=.resect/transforms.js
 `,
 		mcpDescription:
-			"Move a TypeScript/JavaScript file to a new path and rewrite every import that referenced it. Updates relative and alias specifiers, splits mixed barrel imports when only some bindings moved, updates barrel re-exports for same-package moves, and rewrites cross-package imports to use the destination package name (adding a barrel export at the destination when needed). Defaults to `dryRun: true` so callers preview the change first; when `dryRun: false` and `verify: true` (both default) the tool runs `tsc --noEmit` before AND after the move and returns the diagnostic delta in `typecheck` — `newErrors` lists any errors the move introduced. A dirty worktree is returned as an error unless `force: true`. Returns success flag, updated reference list, errors, worktree-dirty flag, and (when verified) the typecheck delta.",
+			"Move a TypeScript/JavaScript file to a new path and rewrite every import that referenced it. Updates relative and alias specifiers, splits mixed barrel imports when only some bindings moved, updates barrel re-exports for same-package moves, and rewrites cross-package imports to use the destination package name (adding a barrel export at the destination when needed). Same-package rewrites preserve each importer's existing specifier style — a relative import stays relative, an aliased one stays aliased — and `prefer` overrides that with 'alias', 'relative', or 'shortest'. Defaults to `dryRun: true` so callers preview the change first; when `dryRun: false` and `verify: true` (both default) the tool runs `tsc --noEmit` before AND after the move and returns the diagnostic delta in `typecheck` — `newErrors` lists any errors the move introduced. A dirty worktree is returned as an error unless `force: true`. Returns success flag, updated reference list, errors, worktree-dirty flag, and (when verified) the typecheck delta.",
 	},
 	{
 		name: "rename",

--- a/src/commands/move.test.ts
+++ b/src/commands/move.test.ts
@@ -74,6 +74,70 @@ async function makeMoveCliProject(): Promise<{
 	return { consumerPath, sourcePath, targetPath, tsconfigPath };
 }
 
+/**
+ * Fixture for issue #173: a project with a tsconfig `paths` alias, one importer
+ * that reaches the moved file relatively and one that reaches it via the alias.
+ */
+async function makeAliasedMoveProject(): Promise<{
+	aliasConsumerPath: string;
+	relativeConsumerPath: string;
+	sourcePath: string;
+	targetPath: string;
+	tsconfigPath: string;
+}> {
+	const dir = await tempDir();
+	const libDir = path.join(dir, "src", "lib");
+	const i18nDir = path.join(libDir, "i18n");
+	const appDir = path.join(dir, "src", "app");
+	await mkdir(i18nDir, { recursive: true });
+	await mkdir(appDir, { recursive: true });
+
+	const tsconfigPath = path.join(dir, "tsconfig.json");
+	await writeFile(
+		tsconfigPath,
+		JSON.stringify(
+			{
+				compilerOptions: {
+					baseUrl: ".",
+					module: "ESNext",
+					moduleResolution: "Bundler",
+					noEmit: true,
+					paths: { "@/*": ["src/*"] },
+					strict: true,
+					target: "ESNext",
+					types: [],
+				},
+				include: ["src/**/*.ts"],
+			},
+			null,
+			2
+		)
+	);
+
+	const sourcePath = path.join(libDir, "locale.ts");
+	const targetPath = path.join(i18nDir, "locale.ts");
+	const relativeConsumerPath = path.join(i18nDir, "config.ts");
+	const aliasConsumerPath = path.join(appDir, "page.ts");
+
+	await writeFile(sourcePath, 'export const locale = "en";\n');
+	await writeFile(
+		relativeConsumerPath,
+		'import { locale } from "../locale";\nexport const config = { locale };\n'
+	);
+	await writeFile(
+		aliasConsumerPath,
+		'import { locale } from "@/lib/locale";\nexport const page = locale;\n'
+	);
+
+	return {
+		aliasConsumerPath,
+		relativeConsumerPath,
+		sourcePath,
+		targetPath,
+		tsconfigPath,
+	};
+}
+
 afterAll(async () => {
 	for (const dir of tempDirs) {
 		await rm(dir, { recursive: true, force: true });
@@ -238,5 +302,154 @@ describe("move CLI verification", () => {
 		expect(await Bun.file(sourcePath).exists()).toBe(false);
 		expect(await Bun.file(targetPath).exists()).toBe(true);
 		expect(await Bun.file(consumerPath).text()).toContain("./nested/source");
+	});
+});
+
+describe("move specifier style (#173)", () => {
+	test("preserves each importer's existing specifier style by default", async () => {
+		const {
+			aliasConsumerPath,
+			relativeConsumerPath,
+			sourcePath,
+			targetPath,
+			tsconfigPath,
+		} = await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(await Bun.file(sourcePath).exists()).toBe(false);
+		expect(await Bun.file(targetPath).exists()).toBe(true);
+
+		// The relative importer must stay relative — an alias here breaks
+		// `node --experimental-strip-types`, which does not resolve tsconfig paths.
+		const relativeConsumer = await Bun.file(relativeConsumerPath).text();
+		expect(relativeConsumer).toContain('from "./locale"');
+		expect(relativeConsumer).not.toContain("@/lib");
+
+		// The aliased importer keeps its alias.
+		expect(await Bun.file(aliasConsumerPath).text()).toContain(
+			'from "@/lib/i18n/locale"'
+		);
+	});
+
+	test("--prefer=relative rewrites aliased importers to relative paths", async () => {
+		const {
+			aliasConsumerPath,
+			relativeConsumerPath,
+			sourcePath,
+			targetPath,
+			tsconfigPath,
+		} = await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--prefer=relative",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(await Bun.file(targetPath).exists()).toBe(true);
+
+		const aliasConsumer = await Bun.file(aliasConsumerPath).text();
+		expect(aliasConsumer).toContain('from "../lib/i18n/locale"');
+		expect(aliasConsumer).not.toContain("@/lib");
+
+		expect(await Bun.file(relativeConsumerPath).text()).toContain(
+			'from "./locale"'
+		);
+	});
+
+	test("--prefer=alias rewrites relative importers to aliases", async () => {
+		const { relativeConsumerPath, sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--prefer=alias",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(await Bun.file(relativeConsumerPath).text()).toContain(
+			'from "@/lib/i18n/locale"'
+		);
+	});
+
+	test("rejects an unknown --prefer strategy", async () => {
+		const { sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--prefer=sideways",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("--prefer must be");
+		// Nothing was written.
+		expect(await Bun.file(sourcePath).exists()).toBe(true);
+		expect(await Bun.file(targetPath).exists()).toBe(false);
+	});
+
+	test("accepts -n=false and performs the move (regression #173)", async () => {
+		const { sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		// Raw `-n=false` used to abort with `TypeError: Unknown option '='`.
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"-n=false",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).not.toContain("Unknown option");
+		expect(await Bun.file(sourcePath).exists()).toBe(false);
+		expect(await Bun.file(targetPath).exists()).toBe(true);
+	});
+
+	test("accepts -n=true and leaves the tree untouched", async () => {
+		const { sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"-n=true",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).not.toContain("Unknown option");
+		expect(await Bun.file(sourcePath).exists()).toBe(true);
+		expect(await Bun.file(targetPath).exists()).toBe(false);
 	});
 });

--- a/src/commands/move.test.ts
+++ b/src/commands/move.test.ts
@@ -119,7 +119,13 @@ async function makeAliasedMoveProject(): Promise<{
 	const relativeConsumerPath = path.join(i18nDir, "config.ts");
 	const aliasConsumerPath = path.join(appDir, "page.ts");
 
-	await writeFile(sourcePath, 'export const locale = "en";\n');
+	// The moved file itself imports a sibling via the alias, so tests can assert
+	// that --prefer reaches the moved module's own imports too (PR #174 review).
+	await writeFile(path.join(libDir, "util.ts"), "export const util = 1;\n");
+	await writeFile(
+		sourcePath,
+		'import { util } from "@/lib/util";\nexport const locale = "en";\nexport const revision = util;\n'
+	);
 	await writeFile(
 		relativeConsumerPath,
 		'import { locale } from "../locale";\nexport const config = { locale };\n'
@@ -369,6 +375,46 @@ describe("move specifier style (#173)", () => {
 		expect(await Bun.file(relativeConsumerPath).text()).toContain(
 			'from "./locale"'
 		);
+	});
+
+	test("--prefer=relative also converts imports inside the moved file", async () => {
+		// PR #174 review (P1): --prefer was applied to external importers but not
+		// to the moved module's own imports, so an alias survived inside the very
+		// file the strip-types use case is about.
+		const { sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--prefer=relative",
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		const moved = await Bun.file(targetPath).text();
+		expect(moved).toContain('from "../util"');
+		expect(moved).not.toContain("@/lib/util");
+	});
+
+	test("default preserves the moved file's own alias import", async () => {
+		const { sourcePath, targetPath, tsconfigPath } =
+			await makeAliasedMoveProject();
+
+		const result = await runCli([
+			"move",
+			sourcePath,
+			targetPath,
+			"--force",
+			"-p",
+			tsconfigPath,
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(await Bun.file(targetPath).text()).toContain('from "@/lib/util"');
 	});
 
 	test("--prefer=alias rewrites relative importers to aliases", async () => {

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -47,8 +47,8 @@ import { createSourceFileFromText } from "../core/source-file.ts";
 import {
 	applyTextChanges,
 	createStructuredEdit,
-	serializeStructuredEdits,
 	type StructuredEdit,
+	serializeStructuredEdits,
 } from "../core/text-changes.ts";
 import { loadTransformConfig } from "../core/transform-config.ts";
 import { applyTransformRules } from "../core/transform-visitor.ts";
@@ -81,6 +81,7 @@ import type {
 import type { TransformRewrite, TransformRule } from "../types/transform.ts";
 import type { MutatingCommandOptions, ProjectConfig } from "../types.ts";
 import { setupCommandContext } from "./command-context.ts";
+import type { PreferStrategy } from "./option-domains.ts";
 
 export interface MoveOptions extends MutatingCommandOptions {
 	source: string;
@@ -93,6 +94,15 @@ export interface MoveOptions extends MutatingCommandOptions {
 	 * A missing/malformed config fails the move and writes nothing.
 	 */
 	transform?: string;
+	/**
+	 * Import-specifier style for rewritten references (issue #173). Omitted, the
+	 * move preserves each importer's existing style — a relative specifier stays
+	 * relative, an aliased one stays aliased. `relative` forces relative paths so
+	 * the result runs under `node --experimental-strip-types`, which does not
+	 * resolve tsconfig `paths`; `alias` forces aliases; `shortest` picks whichever
+	 * specifier is shorter.
+	 */
+	prefer?: PreferStrategy;
 }
 
 export async function moveCommand(options: MoveOptions): Promise<void> {
@@ -105,6 +115,7 @@ export async function moveCommand(options: MoveOptions): Promise<void> {
 		verbose = false,
 		verify = true,
 		project: projectArg,
+		prefer,
 	} = options;
 
 	const absoluteSource = path.resolve(source);
@@ -191,7 +202,8 @@ export async function moveCommand(options: MoveOptions): Promise<void> {
 			json ? false : verbose,
 			workspace ?? undefined,
 			force,
-			transformRules
+			transformRules,
+			prefer
 		);
 
 		// For cross-package moves, run build scripts to update dist/. Keep this
@@ -557,7 +569,8 @@ export async function moveModule(
 	verbose: boolean,
 	workspace?: WorkspaceInfo,
 	force = false,
-	transformRules: TransformRule[] = []
+	transformRules: TransformRule[] = [],
+	prefer?: PreferStrategy
 ): Promise<MoveResult> {
 	const errors: MoveError[] = [];
 	const edits: StructuredEdit[] = [];
@@ -597,8 +610,8 @@ export async function moveModule(
 	const originalSourceContent = await rt.fs.readFile(sourcePath);
 	const shouldNormalizeMovedImports =
 		transformRules.length > 0 &&
-		applyTransformRules(originalSourceContent, targetPath, transformRules).rewrites
-			.length > 0;
+		applyTransformRules(originalSourceContent, targetPath, transformRules)
+			.rewrites.length > 0;
 
 	// Check target doesn't exist. On case-insensitive filesystems, the target
 	// path for a same-directory case-only rename aliases the source path.
@@ -888,15 +901,12 @@ export async function moveModule(
 				targetPath,
 				project,
 				workspace,
-				movedFileExports
+				movedFileExports,
+				prefer
 			);
 
 			if (updates.length > 0) {
-				const edit = createStructuredEdit(
-					filePath,
-					fileAst.text,
-					newContent
-				);
+				const edit = createStructuredEdit(filePath, fileAst.text, newContent);
 				if (edit) {
 					edits.push(edit);
 				}
@@ -937,7 +947,8 @@ export async function moveModule(
 				sourcePath,
 				targetPath,
 				project,
-				workspace
+				workspace,
+				prefer
 			);
 
 			if (updates.length > 0) {
@@ -1120,11 +1131,7 @@ function updateInternalImports(
 	for (const ref of refs) {
 		// Calculate what the import should be from the new location
 		let newSpecifier = preferRelative
-			? calculateRelativeSpecifier(
-					newPath,
-					ref.resolvedPath,
-					ref.specifier
-				)
+			? calculateRelativeSpecifier(newPath, ref.resolvedPath, ref.specifier)
 			: calculateNewSpecifier(
 					ref.specifier,
 					newPath, // Calculate from new location

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -847,7 +847,8 @@ export async function moveModule(
 				targetPath,
 				project,
 				program,
-				shouldNormalizeMovedImports
+				shouldNormalizeMovedImports,
+				prefer
 			);
 
 			if (updates.length > 0) {
@@ -1123,13 +1124,18 @@ function updateInternalImports(
 	newPath: string,
 	project: ProjectConfig,
 	program: ts.Program,
-	preferRelative = false
+	preferRelative = false,
+	prefer?: PreferStrategy
 ): { newContent: string; updates: UpdatedReference[] } {
 	const changes: { start: number; end: number; newText: string }[] = [];
 	const updates: UpdatedReference[] = [];
 
 	for (const ref of refs) {
-		// Calculate what the import should be from the new location
+		// Calculate what the import should be from the new location.
+		// `preferRelative` is the transform-gated normalisation (#103 C);
+		// `prefer` is the user's explicit `--prefer` strategy (#173), which must
+		// reach the moved file's own imports too — otherwise `--prefer=relative`
+		// converts external importers but leaves aliases inside the moved file.
 		let newSpecifier = preferRelative
 			? calculateRelativeSpecifier(newPath, ref.resolvedPath, ref.specifier)
 			: calculateNewSpecifier(
@@ -1137,7 +1143,8 @@ function updateInternalImports(
 					newPath, // Calculate from new location
 					ref.resolvedPath,
 					ref.resolvedPath, // Target hasn't moved
-					project
+					project,
+					prefer
 				);
 
 		// #121: an alias/bare import that the move turned into a relative

--- a/src/commands/option-flags.test.ts
+++ b/src/commands/option-flags.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { parseArgs } from "node:util";
 import type { CliValues } from "./option-flags.ts";
-import { OPTION_FLAGS, PARSE_ARGS_OPTIONS } from "./option-flags.ts";
+import {
+	OPTION_FLAGS,
+	PARSE_ARGS_OPTIONS,
+	preprocessArgs,
+} from "./option-flags.ts";
 
 /**
  * Drift guard: ensures the OPTION_FLAGS table always contains exactly the
@@ -207,5 +212,80 @@ describe("option-flags", () => {
 		const _withArray: CliValues = { "entrypoint-globs": ["src/**/*.ts"] };
 		expect(_withString["entrypoint-globs"]).toBe("src/**/*.ts");
 		expect(_withArray["entrypoint-globs"]).toEqual(["src/**/*.ts"]);
+	});
+});
+
+describe("preprocessArgs (#173)", () => {
+	test("drops a boolean flag given a falsy equals value", () => {
+		expect(preprocessArgs(["move", "a.ts", "b.ts", "--dry-run=false"])).toEqual(
+			["move", "a.ts", "b.ts"]
+		);
+		expect(preprocessArgs(["move", "a.ts", "b.ts", "-n=false"])).toEqual([
+			"move",
+			"a.ts",
+			"b.ts",
+		]);
+	});
+
+	test("treats every falsy spelling as off", () => {
+		for (const value of ["false", "FALSE", "0", "no", "off"]) {
+			expect(preprocessArgs(["move", `--dry-run=${value}`])).toEqual(["move"]);
+		}
+	});
+
+	test("normalizes a truthy equals value to the bare flag", () => {
+		expect(preprocessArgs(["move", "-n=true"])).toEqual(["move", "-n"]);
+		expect(preprocessArgs(["move", "--dry-run=true"])).toEqual([
+			"move",
+			"--dry-run",
+		]);
+		expect(preprocessArgs(["move", "--force=1"])).toEqual(["move", "--force"]);
+	});
+
+	test("leaves bare boolean flags and string flags untouched", () => {
+		expect(
+			preprocessArgs(["move", "-n", "--project=/tmp/x", "--prefer=relative"])
+		).toEqual(["move", "-n", "--project=/tmp/x", "--prefer=relative"]);
+	});
+
+	test("still expands the tidy --fix=<category> shorthand", () => {
+		expect(preprocessArgs(["tidy", "src", "--fix=dead-exports"])).toEqual([
+			"tidy",
+			"src",
+			"--fix",
+			"--fix-category",
+			"dead-exports",
+		]);
+	});
+
+	test("parseArgs accepts -n=false once preprocessed (regression #173)", () => {
+		// Raw `-n=false` makes parseArgs throw `Unknown option '='`.
+		expect(() =>
+			parseArgs({
+				args: ["move", "a.ts", "b.ts", "-n=false"],
+				options: PARSE_ARGS_OPTIONS,
+				allowPositionals: true,
+				strict: true,
+			})
+		).toThrow();
+
+		const { values, positionals } = parseArgs({
+			args: preprocessArgs(["move", "a.ts", "b.ts", "-n=false"]),
+			options: PARSE_ARGS_OPTIONS,
+			allowPositionals: true,
+			strict: true,
+		});
+		expect(values["dry-run"]).toBeUndefined();
+		expect(positionals).toEqual(["move", "a.ts", "b.ts"]);
+	});
+
+	test("parseArgs sees -n=true as dry-run enabled", () => {
+		const { values } = parseArgs({
+			args: preprocessArgs(["move", "a.ts", "b.ts", "-n=true"]),
+			options: PARSE_ARGS_OPTIONS,
+			allowPositionals: true,
+			strict: true,
+		});
+		expect(values["dry-run"]).toBe(true);
 	});
 });

--- a/src/commands/option-flags.test.ts
+++ b/src/commands/option-flags.test.ts
@@ -288,4 +288,56 @@ describe("preprocessArgs (#173)", () => {
 		});
 		expect(values["dry-run"]).toBe(true);
 	});
+
+	// PR #174 review (P2): an unrecognised value must not silently enable the
+	// flag — `--force=fales` would otherwise bypass the dirty-worktree guard.
+	test("leaves an unrecognised boolean value untouched so parseArgs rejects it", () => {
+		expect(preprocessArgs(["move", "--force=fales"])).toEqual([
+			"move",
+			"--force=fales",
+		]);
+		expect(preprocessArgs(["move", "--force="])).toEqual(["move", "--force="]);
+		expect(preprocessArgs(["move", "-n=maybe"])).toEqual(["move", "-n=maybe"]);
+	});
+
+	test("a typo'd boolean value is a parse error, not an enabled flag", () => {
+		expect(() =>
+			parseArgs({
+				args: preprocessArgs(["move", "a.ts", "b.ts", "--force=fales"]),
+				options: PARSE_ARGS_OPTIONS,
+				allowPositionals: true,
+				strict: true,
+			})
+		).toThrow();
+	});
+
+	// PR #174 review (P2): parseArgs treats everything after `--` as positional.
+	test("stops normalizing after the -- separator", () => {
+		expect(
+			preprocessArgs(["move", "--", "--dry-run=false", "target.ts"])
+		).toEqual(["move", "--", "--dry-run=false", "target.ts"]);
+		expect(preprocessArgs(["move", "--", "-n=false"])).toEqual([
+			"move",
+			"--",
+			"-n=false",
+		]);
+	});
+
+	test("a dash-prefixed path after -- survives as a positional", () => {
+		const { positionals } = parseArgs({
+			args: preprocessArgs(["move", "--", "--dry-run=false", "target.ts"]),
+			options: PARSE_ARGS_OPTIONS,
+			allowPositionals: true,
+			strict: true,
+		});
+		expect(positionals).toEqual(["move", "--dry-run=false", "target.ts"]);
+	});
+
+	test("still normalizes flags before the separator", () => {
+		expect(preprocessArgs(["move", "-n=false", "--", "-n=false"])).toEqual([
+			"move",
+			"--",
+			"-n=false",
+		]);
+	});
 });

--- a/src/commands/option-flags.ts
+++ b/src/commands/option-flags.ts
@@ -79,45 +79,89 @@ for (const [name, spec] of Object.entries(OPTION_FLAGS) as [
 }
 
 const FALSY_VALUES = new Set(["false", "0", "no", "off"]);
+const TRUTHY_VALUES = new Set(["true", "1", "yes", "on"]);
+
+/**
+ * Normalize `<flag>=<value>` for a boolean flag into the bare-flag form
+ * `parseArgs` accepts. Only explicit truthy/falsy spellings are recognised:
+ * returning `null` for anything else leaves the token untouched so `parseArgs`
+ * raises its own strict error, rather than turning a typo like `--force=fales`
+ * into an enabled `--force` that would silently bypass the worktree guard.
+ */
+function normalizeBooleanFlag(
+	bareFlag: string,
+	rawValue: string
+): string[] | null {
+	const value = rawValue.toLowerCase();
+	if (FALSY_VALUES.has(value)) {
+		return [];
+	}
+	if (TRUTHY_VALUES.has(value)) {
+		return [bareFlag];
+	}
+	return null;
+}
 
 /**
  * Preprocess CLI arguments to normalize special flags before passing to parseArgs.
  * Standardizes boolean flags passed with equals syntax (e.g. -n=false, --dry-run=false).
+ *
+ * Everything after a bare `--` is left verbatim: `parseArgs` treats those tokens
+ * as positionals, so rewriting them would drop dash-prefixed paths such as
+ * `move -- --dry-run=false target.ts`.
  */
 export function preprocessArgs(cliArgs: string[]): string[] {
-	return cliArgs.flatMap((arg) => {
-		if (cliArgs[0] === "tidy" && arg.startsWith("--fix=")) {
-			return ["--fix", "--fix-category", arg.slice("--fix=".length)];
+	const out: string[] = [];
+	let sawSeparator = false;
+
+	for (const arg of cliArgs) {
+		if (sawSeparator) {
+			out.push(arg);
+			continue;
+		}
+		if (arg === "--") {
+			sawSeparator = true;
+			out.push(arg);
+			continue;
 		}
 
-		if (arg.startsWith("--")) {
-			const eqIndex = arg.indexOf("=");
-			if (eqIndex !== -1) {
+		if (cliArgs[0] === "tidy" && arg.startsWith("--fix=")) {
+			out.push("--fix", "--fix-category", arg.slice("--fix=".length));
+			continue;
+		}
+
+		const eqIndex = arg.indexOf("=");
+		let normalized: string[] | null = null;
+
+		if (eqIndex !== -1) {
+			if (arg.startsWith("--")) {
 				const flagName = arg.slice(2, eqIndex);
 				if (BOOLEAN_FLAGS.has(flagName)) {
-					const value = arg.slice(eqIndex + 1).toLowerCase();
-					if (FALSY_VALUES.has(value)) {
-						return [];
-					}
-					return [`--${flagName}`];
+					normalized = normalizeBooleanFlag(
+						`--${flagName}`,
+						arg.slice(eqIndex + 1)
+					);
 				}
-			}
-		} else if (arg.startsWith("-") && arg.length > 1) {
-			const eqIndex = arg.indexOf("=");
-			if (eqIndex !== -1) {
+			} else if (arg.startsWith("-") && arg.length > 1) {
 				const shortFlag = arg.slice(1, eqIndex);
-				if (SHORT_BOOLEAN_FLAGS.has(shortFlag)) {
-					const value = arg.slice(eqIndex + 1).toLowerCase();
-					if (FALSY_VALUES.has(value)) {
-						return [];
-					}
-					return [`-${shortFlag}`];
+				const longName = SHORT_BOOLEAN_FLAGS.get(shortFlag);
+				if (longName !== undefined) {
+					normalized = normalizeBooleanFlag(
+						`-${shortFlag}`,
+						arg.slice(eqIndex + 1)
+					);
 				}
 			}
 		}
 
-		return [arg];
-	});
+		if (normalized === null) {
+			out.push(arg);
+		} else {
+			out.push(...normalized);
+		}
+	}
+
+	return out;
 }
 
 type FlagValue<F extends FlagSpec> = F extends { type: "boolean" }

--- a/src/commands/option-flags.ts
+++ b/src/commands/option-flags.ts
@@ -63,6 +63,63 @@ export const PARSE_ARGS_OPTIONS = OPTION_FLAGS as NonNullable<
 	ParseArgsConfig["options"]
 >;
 
+const BOOLEAN_FLAGS = new Set<string>();
+const SHORT_BOOLEAN_FLAGS = new Map<string, string>();
+
+for (const [name, spec] of Object.entries(OPTION_FLAGS) as [
+	string,
+	FlagSpec,
+][]) {
+	if (spec.type === "boolean") {
+		BOOLEAN_FLAGS.add(name);
+		if (spec.short) {
+			SHORT_BOOLEAN_FLAGS.set(spec.short, name);
+		}
+	}
+}
+
+const FALSY_VALUES = new Set(["false", "0", "no", "off"]);
+
+/**
+ * Preprocess CLI arguments to normalize special flags before passing to parseArgs.
+ * Standardizes boolean flags passed with equals syntax (e.g. -n=false, --dry-run=false).
+ */
+export function preprocessArgs(cliArgs: string[]): string[] {
+	return cliArgs.flatMap((arg) => {
+		if (cliArgs[0] === "tidy" && arg.startsWith("--fix=")) {
+			return ["--fix", "--fix-category", arg.slice("--fix=".length)];
+		}
+
+		if (arg.startsWith("--")) {
+			const eqIndex = arg.indexOf("=");
+			if (eqIndex !== -1) {
+				const flagName = arg.slice(2, eqIndex);
+				if (BOOLEAN_FLAGS.has(flagName)) {
+					const value = arg.slice(eqIndex + 1).toLowerCase();
+					if (FALSY_VALUES.has(value)) {
+						return [];
+					}
+					return [`--${flagName}`];
+				}
+			}
+		} else if (arg.startsWith("-") && arg.length > 1) {
+			const eqIndex = arg.indexOf("=");
+			if (eqIndex !== -1) {
+				const shortFlag = arg.slice(1, eqIndex);
+				if (SHORT_BOOLEAN_FLAGS.has(shortFlag)) {
+					const value = arg.slice(eqIndex + 1).toLowerCase();
+					if (FALSY_VALUES.has(value)) {
+						return [];
+					}
+					return [`-${shortFlag}`];
+				}
+			}
+		}
+
+		return [arg];
+	});
+}
+
 type FlagValue<F extends FlagSpec> = F extends { type: "boolean" }
 	? boolean
 	: F extends { type: "string"; multiple: true }

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -54,6 +54,13 @@ export const COMMANDS: CommandDef[] = [
 				logger.error(`Run '${CLI_NAME} move --help' for usage`);
 				process.exit(1);
 			}
+			const prefer = values.prefer;
+			if (prefer !== undefined && !isInDomain(PREFER_STRATEGIES, prefer)) {
+				logger.error(
+					"Error: --prefer must be 'alias', 'relative', or 'shortest'"
+				);
+				process.exit(1);
+			}
 			await moveCommand({
 				source,
 				target,
@@ -65,6 +72,7 @@ export const COMMANDS: CommandDef[] = [
 				project: values.project,
 				workspace: values.workspace,
 				transform: values.transform,
+				prefer,
 			});
 		},
 	},

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -16,8 +16,8 @@ import {
 	applyTextChanges,
 	createStructuredEdit,
 	deduplicateChanges,
-	serializeStructuredEdits,
 	type StructuredEdit,
+	serializeStructuredEdits,
 	type TextChange,
 } from "../core/text-changes.ts";
 import {

--- a/src/commands/tidy.ts
+++ b/src/commands/tidy.ts
@@ -1381,11 +1381,19 @@ export function formatTidyReport(report: TidyReport): string {
 export async function tidyCommand(options: TidyOptions): Promise<void> {
 	assertExperimental(options.experimental);
 	const report = await buildTidyReport(options);
-	const result = options.fix
-		? options.dryRun
+	let result: TidyApplyResult;
+	if (options.fix) {
+		result = options.dryRun
 			? await previewTidyFixes(report, options)
-			: await applyTidyFixes(report, options)
-		: { report, success: true, errors: [] };
+			: await applyTidyFixes(report, options);
+	} else {
+		result = {
+			report,
+			success: true,
+			errors: [],
+			worktreeDirtyRollbackDisabled: false,
+		};
+	}
 	const output = options.json
 		? `${JSON.stringify(result.report, null, 2)}\n`
 		: formatTidyReport(result.report);

--- a/src/commands/unused.test.ts
+++ b/src/commands/unused.test.ts
@@ -24,9 +24,7 @@ describe("unused command", () => {
 		expect(serverSource).toContain(
 			"orphanFileCount: report.orphanFiles.length"
 		);
-		expect(serverSource).toContain(
-			"skippedFileCount: report.skippedFileCount"
-		);
+		expect(serverSource).toContain("skippedFileCount: report.skippedFileCount");
 		expect(serverSource).toContain(
 			"coverageIncomplete: report.coverageIncomplete"
 		);

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -101,7 +101,7 @@ function isCacheValid(
 		return false;
 	}
 	for (const file of currentFiles) {
-		if (!cached.imports.has(file) && !cached.skippedFiles.includes(file)) {
+		if (!(cached.imports.has(file) || cached.skippedFiles.includes(file))) {
 			return false;
 		}
 	}

--- a/src/core/resolver.test.ts
+++ b/src/core/resolver.test.ts
@@ -785,3 +785,100 @@ describe("calculateNewSpecifier alias slash/extension normalization (#160)", () 
 		expect(result).toBe("@my-org/shared-schemas/types/audit-log");
 	});
 });
+
+// ─── calculateNewSpecifier specifier-style preservation (#173) ─────────────
+
+describe("calculateNewSpecifier specifier style (#173)", () => {
+	// Mirrors the issue repro: a project with a tsconfig `paths` alias, where a
+	// relative import rewritten to an alias breaks `node --experimental-strip-types`
+	// (which does not resolve tsconfig paths).
+	const project = makeProject("/repo", { "@/*": ["src/*"] });
+	const oldTarget = "/repo/src/lib/locale.ts";
+	const newTarget = "/repo/src/lib/i18n/locale.ts";
+	const sibling = "/repo/src/lib/i18n/config.ts";
+	const distant = "/repo/src/app/page.ts";
+
+	test("keeps a relative specifier relative even when an alias covers the target", () => {
+		// Regression: this used to return "@/lib/i18n/locale" because a relative
+		// import fell through to findAliasForPath().
+		const result = calculateNewSpecifier(
+			"../locale",
+			sibling,
+			oldTarget,
+			newTarget,
+			project
+		);
+
+		expect(isRelativeImport(result)).toBe(true);
+		expect(result).toBe("./locale");
+	});
+
+	test("keeps an aliased specifier aliased", () => {
+		const result = calculateNewSpecifier(
+			"@/lib/locale",
+			distant,
+			oldTarget,
+			newTarget,
+			project
+		);
+
+		expect(result).toBe("@/lib/i18n/locale");
+	});
+
+	test("prefer 'relative' rewrites an aliased specifier to a relative path", () => {
+		const result = calculateNewSpecifier(
+			"@/lib/locale",
+			distant,
+			oldTarget,
+			newTarget,
+			project,
+			"relative"
+		);
+
+		expect(isRelativeImport(result)).toBe(true);
+		expect(result).toBe("../lib/i18n/locale");
+	});
+
+	test("prefer 'alias' rewrites a relative specifier to an alias", () => {
+		const result = calculateNewSpecifier(
+			"../locale",
+			sibling,
+			oldTarget,
+			newTarget,
+			project,
+			"alias"
+		);
+
+		expect(result).toBe("@/lib/i18n/locale");
+	});
+
+	test("prefer 'shortest' picks the relative form for a near importer", () => {
+		const result = calculateNewSpecifier(
+			"../locale",
+			sibling,
+			oldTarget,
+			newTarget,
+			project,
+			"shortest"
+		);
+
+		// "./locale" is shorter than "@/lib/i18n/locale"
+		expect(result).toBe("./locale");
+	});
+
+	test("prefer 'shortest' picks the alias form for a deeply nested importer", () => {
+		const deep = "/repo/src/features/a/b/c/deep.ts";
+
+		const result = calculateNewSpecifier(
+			"../../../../locale",
+			deep,
+			oldTarget,
+			newTarget,
+			project,
+			"shortest"
+		);
+
+		// "@/lib/i18n/locale" is shorter than "../../../../lib/i18n/locale"
+		expect(result).toBe("@/lib/i18n/locale");
+	});
+});

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import ts from "typescript";
+import type { PreferStrategy } from "../commands/option-domains.ts";
 import type { ProjectConfig } from "../types.ts";
 import {
 	removeExtension,
@@ -94,10 +95,71 @@ export function calculateNewSpecifier(
 	fromFile: string,
 	oldTargetPath: string,
 	newTargetPath: string,
-	project: ProjectConfig
+	project: ProjectConfig,
+	prefer?: PreferStrategy
 ): string {
-	// If it's a path alias, check if we should preserve it or update it
+	if (prefer === "relative") {
+		return calculateRelativeSpecifier(fromFile, newTargetPath, oldSpecifier);
+	}
+
 	const aliasMatch = matchPathAlias(oldSpecifier, project);
+
+	if (prefer === "alias") {
+		if (aliasMatch) {
+			const updated = updateAliasedSpecifier(
+				oldSpecifier,
+				aliasMatch,
+				oldTargetPath,
+				newTargetPath,
+				fromFile,
+				project
+			);
+			if (updated.startsWith("../") || updated.startsWith("./")) {
+				const crossPackageAlias = findAliasForPath(newTargetPath, project);
+				if (crossPackageAlias) {
+					return crossPackageAlias;
+				}
+			}
+			return updated;
+		}
+		const alias = findAliasForPath(newTargetPath, project);
+		if (alias) {
+			return alias;
+		}
+		return calculateRelativeSpecifier(fromFile, newTargetPath, oldSpecifier);
+	}
+
+	if (prefer === "shortest") {
+		let aliasedSpecifier: string | null = null;
+		if (aliasMatch) {
+			aliasedSpecifier = updateAliasedSpecifier(
+				oldSpecifier,
+				aliasMatch,
+				oldTargetPath,
+				newTargetPath,
+				fromFile,
+				project
+			);
+		}
+		if (!aliasedSpecifier || aliasedSpecifier.startsWith(".")) {
+			aliasedSpecifier = findAliasForPath(newTargetPath, project);
+		}
+		const relativeSpecifier = calculateRelativeSpecifier(
+			fromFile,
+			newTargetPath,
+			oldSpecifier
+		);
+		if (
+			aliasedSpecifier &&
+			aliasedSpecifier.length < relativeSpecifier.length
+		) {
+			return aliasedSpecifier;
+		}
+		return relativeSpecifier;
+	}
+
+	// Default behavior (prefer === undefined):
+	// If the old specifier was a path alias: update aliased specifier
 	if (aliasMatch) {
 		const updated = updateAliasedSpecifier(
 			oldSpecifier,
@@ -118,12 +180,8 @@ export function calculateNewSpecifier(
 		return updated;
 	}
 
-	// For relative imports, try to find an alias first (for cross-package moves)
+	// For relative imports: preserve relative import style
 	if (isRelativeImport(oldSpecifier)) {
-		const crossPackageAlias = findAliasForPath(newTargetPath, project);
-		if (crossPackageAlias) {
-			return crossPackageAlias;
-		}
 		return calculateRelativeSpecifier(fromFile, newTargetPath, oldSpecifier);
 	}
 

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -386,7 +386,14 @@ export function calculateRelativeSpecifier(
 		: path.resolve(fromFile);
 	const absToFile = path.isAbsolute(toFile) ? toFile : path.resolve(toFile);
 	const fromDir = path.dirname(absFromFile);
-	let relativePath = path.relative(fromDir, absToFile);
+	// `path.relative` yields platform separators, so on Windows this is
+	// `..\lib\locale`. A module specifier is a string literal: backslashes read
+	// as escapes, not separators, and the `/index` collapse below would miss.
+	// Module specifiers are always POSIX-style.
+	let relativePath = path
+		.relative(fromDir, absToFile)
+		.split(path.sep)
+		.join("/");
 
 	// Preserve the original specifier's extension style:
 	// if the old specifier had a .ts/.tsx/etc extension, keep it;

--- a/src/core/text-changes.test.ts
+++ b/src/core/text-changes.test.ts
@@ -5,8 +5,8 @@ import {
 	createStructuredEdit,
 	deduplicateChanges,
 	formatUnifiedDiff,
-	serializeStructuredEdits,
 	type StructuredEdit,
+	serializeStructuredEdits,
 	type TextChange,
 } from "./text-changes.ts";
 
@@ -173,7 +173,9 @@ describe("structured edit previews", () => {
 	});
 
 	test("returns no edit when the content is unchanged", () => {
-		expect(createStructuredEdit("src/example.ts", "same", "same")).toBeUndefined();
+		expect(
+			createStructuredEdit("src/example.ts", "same", "same")
+		).toBeUndefined();
 	});
 
 	test("rejects a structured edit when its old text is stale", () => {

--- a/src/core/text-changes.ts
+++ b/src/core/text-changes.ts
@@ -98,8 +98,7 @@ export function createStructuredEdit(
 	let commonSuffixLength = 0;
 	while (
 		commonSuffixLength < sharedLength - commonPrefixLength &&
-		before[before.length - commonSuffixLength - 1] ===
-			after[after.length - commonSuffixLength - 1]
+		before.at(-commonSuffixLength - 1) === after.at(-commonSuffixLength - 1)
 	) {
 		commonSuffixLength += 1;
 	}

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import ts from "typescript";
 import { logger } from "../cli-logger.ts";
+import type { PreferStrategy } from "../commands/option-domains.ts";
 import type { ExportInfo } from "../types/analysis.ts";
 import type { ImportBinding, ModuleReference } from "../types/graph.ts";
 import type { UpdatedReference } from "../types/move.ts";
@@ -39,6 +40,10 @@ export interface CrossPackageMoveContext {
  *
  * When imports go through a barrel and only some bindings come from the moved file,
  * this will split the import into two: one for moved exports, one for remaining exports.
+ *
+ * `prefer` overrides the default specifier style for same-package rewrites
+ * (issue #173). Left undefined, a relative import stays relative and an aliased
+ * import stays aliased.
  */
 export function updateFileReferences(
 	sourceFile: ts.SourceFile,
@@ -47,7 +52,8 @@ export function updateFileReferences(
 	newPath: string,
 	project: ProjectConfig,
 	workspace?: WorkspaceInfo,
-	movedFileExports?: ExportInfo[]
+	movedFileExports?: ExportInfo[],
+	prefer?: PreferStrategy
 ): { newContent: string; updates: UpdatedReference[] } {
 	const changes: TextChange[] = [];
 	const updates: UpdatedReference[] = [];
@@ -203,7 +209,8 @@ export function updateFileReferences(
 					ref.sourceFile,
 					oldPath,
 					newPath,
-					project
+					project,
+					prefer
 				);
 		} else {
 			newSpecifier = calculateNewSpecifier(
@@ -211,7 +218,8 @@ export function updateFileReferences(
 				ref.sourceFile,
 				oldPath,
 				newPath,
-				project
+				project,
+				prefer
 			);
 		}
 
@@ -551,7 +559,8 @@ export function updateBarrelExports(
 	oldPath: string,
 	newPath: string,
 	project: ProjectConfig,
-	workspace?: WorkspaceInfo
+	workspace?: WorkspaceInfo,
+	prefer?: PreferStrategy
 ): { newContent: string; updates: UpdatedReference[] } {
 	const changes: TextChange[] = [];
 	const removals: { start: number; end: number }[] = [];
@@ -622,7 +631,8 @@ export function updateBarrelExports(
 				sourceFile.fileName,
 				oldPath,
 				newPath,
-				project
+				project,
+				prefer
 			);
 
 			if (newSpecifier !== specifier) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,18 @@ export type {
 	SimilarityFilterOptions,
 } from "./core/similarity.ts";
 export { analyzeSimilarity } from "./core/similarity.ts";
+// ── Core types ──────────────────────────────────────────────────────
+export type {
+	SerializedEdit,
+	StructuredEdit,
+	TextChange,
+} from "./core/text-changes.ts";
+export {
+	applyStructuredEdits,
+	createStructuredEdit,
+	formatUnifiedDiff,
+	serializeStructuredEdits,
+} from "./core/text-changes.ts";
 // ── Core: transform config (epic #103) ─────────────────────────────
 export {
 	DEFAULT_TRANSFORM_CONFIG_PATH,
@@ -341,16 +353,4 @@ export type {
 	TransformRewrite,
 	TransformRule,
 } from "./types/transform.ts";
-// ── Core types ──────────────────────────────────────────────────────
-export type {
-	SerializedEdit,
-	StructuredEdit,
-	TextChange,
-} from "./core/text-changes.ts";
-export {
-	applyStructuredEdits,
-	createStructuredEdit,
-	formatUnifiedDiff,
-	serializeStructuredEdits,
-} from "./core/text-changes.ts";
 export type { ProjectConfig, ProjectReference } from "./types.ts";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1721,9 +1721,7 @@ async function aliasTool(args: {
 			? renameImportSpecifiers(absoluteTarget, renames, project)
 			: normalizeImports(absoluteTarget, args.prefer ?? "alias", project);
 	result.edits =
-		result.conflicts.length === 0
-			? await planAliasEdits(result.changes)
-			: [];
+		result.conflicts.length === 0 ? await planAliasEdits(result.changes) : [];
 
 	let delta: VerificationResult | undefined;
 	let rolledBack = false;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1504,6 +1504,7 @@ async function moveTool(args: {
 	verify: boolean;
 	verbose: boolean;
 	transform?: string;
+	prefer?: PreferStrategy;
 }): Promise<CallToolResult> {
 	const absoluteSource = path.resolve(args.source);
 	const absoluteTarget = path.resolve(args.target);
@@ -1547,9 +1548,10 @@ async function moveTool(args: {
 			workspace,
 			// MCP gates force at the worktree layer above; moveModule's conflict
 			// force stays at its default (unchanged behaviour). The 8th arg threads
-			// the loaded transform rules (#123).
+			// the loaded transform rules (#123), the 9th the specifier style (#173).
 			false,
-			transformRules
+			transformRules,
+			args.prefer
 		);
 
 	const shouldVerify = args.verify && !args.dryRun;
@@ -1839,6 +1841,12 @@ server.registerTool(
 				.describe(
 					"Path to a declarative `.resect/transforms.js` config (epic #103), resolved relative to the project root. Parsed/validated before the move; a missing or malformed config fails the move and writes nothing"
 				),
+			prefer: z
+				.enum(PREFER_STRATEGIES)
+				.optional()
+				.describe(
+					"Import-specifier style for rewritten references (#173). Omit to preserve each importer's existing style (relative stays relative, aliased stays aliased). 'relative' forces relative paths — needed when the output must run under `node --experimental-strip-types`, which does not resolve tsconfig paths"
+				),
 		},
 	},
 	async ({
@@ -1850,6 +1858,7 @@ server.registerTool(
 		verify,
 		verbose,
 		transform,
+		prefer,
 	}) => {
 		return withErrorHandling(async () => {
 			return moveTool({
@@ -1861,6 +1870,7 @@ server.registerTool(
 				verify: verify ?? true,
 				verbose: verbose ?? false,
 				transform,
+				prefer,
 			});
 		});
 	}


### PR DESCRIPTION
Moving a file in a project with tsconfig `paths` used to rewrite relative imports into alias specifiers. That is right for bundlers, but standalone Node runners (`node --experimental-strip-types`) do not resolve tsconfig `paths`, so the moved code failed with `ERR_MODULE_NOT_FOUND`. This makes the rewrite style-preserving by default and adds `--prefer` to override it.

## What changed

- **`calculateNewSpecifier` preserves specifier style.** A relative import stays relative; an aliased import stays aliased. Previously a relative import fell through to `findAliasForPath()` and came back as an alias.
- **New `--prefer=alias|relative|shortest` on `move`**, threaded through all three entry points: the CLI dispatcher (`registry.ts`, validated against `PREFER_STRATEGIES`), the MCP `move` tool (`z.enum`), and the library `MoveOptions`. `shortest` picks whichever of the two specifiers is shorter.
- **Boolean flags accept equals syntax.** `-n=false` and `--dry-run=false` previously aborted with `TypeError: Unknown option '='` from `parseArgs`. The new `preprocessArgs()` normalises them (`false`/`0`/`no`/`off` drop the flag, anything else yields the bare flag) and absorbs the existing `tidy --fix=<category>` shorthand.
- **Help text and MCP description** updated to document the new flag and the preservation default.

## Why

Closes #173.

## Scope note

Cross-package moves are deliberately unaffected — they still resolve through `findCrossPackageImport()` in `updateFileReferences()`, so a genuine package-boundary move still produces a package specifier. Only the same-package alias fallback was removed.

## Also included: a pre-existing CI fix (unrelated to #173)

`main` is currently red on its own tip (`b1bc838`) — `pnpm run lint` exits 1 before the test step ever runs, so every PR inherits a failing build. Rather than open this PR on a knowingly-red base, the last commit fixes it:

- `text-changes.ts` — `lint/style/useAtIndex`. Note Biome's own suggested fix is wrong: it emits `after.at(commonSuffixLength + 1)`, dropping the negation. The correct form is `.at(-commonSuffixLength - 1)`.
- `tidy.ts` — `lint/style/noNestedTernary`. Unnesting it and annotating the result as `TidyApplyResult` surfaced a latent gap the inferred union had hidden: the no-fix branch omitted the required `worktreeDirtyRollbackDisabled`. It is `false` there, matching the audit-only paths, since nothing is mutated.
- The other files in that commit are `biome check --write` formatting only.

Happy to split that into its own PR if you'd rather keep this one strictly scoped to #173.

## Testing

- `bun test` — 794 pass, 0 fail across 56 files (19 new tests for this change).
- `pnpm run typecheck` — clean.
- `pnpm run lint` (the exact CI command) — exit 0, where it exits 1 on `main`.
- Pre-commit hook ran 461 affected tests on the feature commit, all passing.

New coverage:
- `resolver.test.ts` — 6 tests for the default preservation plus each `--prefer` strategy.
- `option-flags.test.ts` — 7 `preprocessArgs` tests, including one asserting raw `-n=false` still throws in bare `parseArgs` (so the regression stays pinned).
- `move.test.ts` — 6 CLI end-to-end tests through the real `bun src/cli.ts` entry point, covering both issue symptoms and the invalid-strategy rejection path.

## Risk / Rollout

Low-to-moderate: this changes the default output of `move` for relative importers in aliased projects. Anyone who relied on the implicit relative-to-alias promotion can restore the old behaviour with `--prefer=alias`. The full suite, including the existing cross-package and barrel move tests, passes unchanged.

## Note on size

The #173 commit is ~608 changed lines, above the usual split threshold, but roughly two thirds is test code. The remainder is not separable: the repo's own parity guards (`src/index.test.ts` for CLI-to-library, `mcp-schema-parity.test.ts`, `option-flags.test.ts`) fail unless a new command option lands across CLI, MCP, and the library API in one change.
