### PR TITLE
fix(analysis): reduce noisy project findings

### DIFF
--- a/src/commands/naming.test.ts
+++ b/src/commands/naming.test.ts
@@ -147,6 +147,55 @@ describe("naming command", () => {
 		await cleanup(dir);
 	});
 
+	test("does not report a no-op rename for conventional index files", async () => {
+		const dir = await makeFixture("index-no-op", {
+			"src/group/alpha-one.ts": functionFile("alphaOne"),
+			"src/group/beta-two.ts": functionFile("betaTwo"),
+			"src/group/gamma-three.ts": functionFile("gammaThree"),
+			"src/group/index.ts": 'export * from "./alpha-one";\n',
+		});
+
+		const result = await captureOutput(async () =>
+			namingCommand({ directory: path.join(dir, "src"), json: true })
+		);
+		const report = JSON.parse(result.stdout) as {
+			findings: Array<{ file: string; suggestedName: string }>;
+		};
+		expect(report.findings).not.toContainEqual(
+			expect.objectContaining({
+				file: "group/index.ts",
+				suggestedName: "index.ts",
+			})
+		);
+
+		await cleanup(dir);
+	});
+
+	test("preserves Next App Router convention filenames", async () => {
+		const dir = await makeFixture("next-conventions", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { jsx: "preserve", strict: true },
+				include: ["**/*.ts", "**/*.tsx"],
+			}),
+			"src/app/admin/alphaOne.tsx": functionFile("alphaOne"),
+			"src/app/admin/betaTwo.tsx": functionFile("betaTwo"),
+			"src/app/admin/gammaThree.tsx": functionFile("gammaThree"),
+			"src/app/admin/not-found.tsx": functionFile("NotFound"),
+		});
+
+		const result = await captureOutput(async () =>
+			namingCommand({ directory: path.join(dir, "src"), json: true })
+		);
+		const report = JSON.parse(result.stdout) as {
+			findings: Array<{ file: string }>;
+		};
+		expect(report.findings.map((finding) => finding.file)).not.toContain(
+			"app/admin/not-found.tsx"
+		);
+
+		await cleanup(dir);
+	});
+
 	test("does not report when no directory casing has a majority", async () => {
 		const dir = await makeFixture("no-majority", {
 			...withFiles(CAMEL_NAMES.slice(0, 5), functionFile),

--- a/src/commands/naming.ts
+++ b/src/commands/naming.ts
@@ -46,6 +46,20 @@ const SNAKE_CASE_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)+$/;
 const LOWER_TO_UPPER_BOUNDARY = /([a-z0-9])([A-Z])/g;
 const ACRONYM_BOUNDARY = /([A-Z]+)([A-Z][a-z])/g;
 const NON_WORD_SEPARATOR = /[^A-Za-z0-9]+/g;
+const NEXT_APP_ROUTER_STEMS = new Set([
+	"default",
+	"error",
+	"global-error",
+	"layout",
+	"loading",
+	"not-found",
+	"opengraph-image",
+	"page",
+	"route",
+	"sitemap",
+	"template",
+	"twitter-image",
+]);
 
 type ConcreteExportKind = Exclude<PrimaryExportKind, "mixed" | "unknown">;
 type ProjectGraphResult = Awaited<
@@ -471,6 +485,13 @@ function findMajority(files: FileNamingInfo[]): Majority | null {
 	};
 }
 
+function isNextAppRouterConvention(file: FileNamingInfo): boolean {
+	return (
+		file.file.split(path.sep).includes("app") &&
+		NEXT_APP_ROUTER_STEMS.has(file.stem)
+	);
+}
+
 function round2(value: number): number {
 	return Math.round(value * 100) / 100;
 }
@@ -516,23 +537,30 @@ function analyzeNaming(
 	const violations: NamingViolation[] = [];
 
 	for (const group of groups.values()) {
-		if (group.length < minSiblings) {
+		const namingCandidates = group.filter(
+			(file) => !isNextAppRouterConvention(file)
+		);
+		if (namingCandidates.length < minSiblings) {
 			continue;
 		}
-		const majority = findMajority(group);
+		const majority = findMajority(namingCandidates);
 		if (!majority || majority.percent < majorityThreshold) {
 			continue;
 		}
-		for (const file of group) {
+		for (const file of namingCandidates) {
 			if (
 				file.currentCasing === majority.casing ||
 				isCasingJustified(file.currentCasing, file.primaryExport.kind)
 			) {
 				continue;
 			}
+			const violation = toViolation(file, majority);
+			if (path.basename(file.file) === violation.suggestedName) {
+				continue;
+			}
 			violations.push({
-				...toViolation(file, majority),
-				siblingCount: group.length,
+				...violation,
+				siblingCount: namingCandidates.length,
 			});
 		}
 	}

--- a/src/core/similarity.test.ts
+++ b/src/core/similarity.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
 	analyzeSimilarity,
@@ -102,6 +104,38 @@ describe("analyzeSimilarity", () => {
 		);
 		expect(report.groups).toHaveLength(0);
 		expect(report.packageCount).toBeUndefined();
+	});
+
+	test("accepts an explicit tsconfig file as the project path", async () => {
+		const directory = await mkdtemp(
+			path.join(tmpdir(), "resect-similar-project-")
+		);
+		try {
+			const sourceDirectory = path.join(directory, "src");
+			await mkdir(sourceDirectory, { recursive: true });
+			await writeFile(
+				path.join(sourceDirectory, "example.ts"),
+				"export function calculateTotal(values: number[]) { return values.reduce((total, value) => total + value, 0); }\n"
+			);
+			const tsconfigPath = path.join(directory, "tsconfig.json");
+			await writeFile(
+				tsconfigPath,
+				JSON.stringify({
+					compilerOptions: { strict: true },
+					include: ["src/**/*.ts"],
+				})
+			);
+
+			const report = await analyzeSimilarity({
+				directory: sourceDirectory,
+				project: tsconfigPath,
+			});
+
+			expect(report.totalFiles).toBe(1);
+			expect(report.totalFunctions).toBe(1);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/src/core/similarity.ts
+++ b/src/core/similarity.ts
@@ -634,9 +634,13 @@ export async function scanProjectFunctions(
 	projectRoot?: string
 ): Promise<{ functions: FunctionInfo[]; totalFiles: number }> {
 	const absoluteDir = path.resolve(directory);
-	const rootDir = projectRoot
-		? path.resolve(projectRoot)
-		: findProjectRoot(absoluteDir);
+	let rootDir = findProjectRoot(absoluteDir);
+	if (projectRoot) {
+		const resolvedProjectPath = path.resolve(projectRoot);
+		rootDir = ts.sys.directoryExists(resolvedProjectPath)
+			? resolvedProjectPath
+			: path.dirname(resolvedProjectPath);
+	}
 
 	const discovery = discoverProject(rootDir);
 	const allFiles = Array.from(discovery.fileOwnership.keys()).filter(

--- a/src/core/tsconfig-discovery.test.ts
+++ b/src/core/tsconfig-discovery.test.ts
@@ -102,4 +102,35 @@ describe("discoverProject cache", () => {
 			await rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	test("ignores nested agent worktrees during tsconfig discovery", async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "resect-discovery-agents-"));
+		try {
+			await mkdir(path.join(dir, "src"), { recursive: true });
+			await writeFile(
+				path.join(dir, "src", "index.ts"),
+				"export const live = true;\n"
+			);
+			await writeFile(
+				path.join(dir, "tsconfig.json"),
+				JSON.stringify({ include: ["src/**/*.ts"] })
+			);
+
+			for (const agentDirectory of [".claude", ".codex"]) {
+				const worktree = path.join(dir, agentDirectory, "worktrees", "nested");
+				await mkdir(worktree, { recursive: true });
+				await writeFile(
+					path.join(worktree, "tsconfig.json"),
+					JSON.stringify({ include: ["src/**/*.ts"] })
+				);
+			}
+
+			const discovery = discoverProject(dir);
+			expect(discovery.configs.map((config) => config.path)).toEqual([
+				path.join(dir, "tsconfig.json"),
+			]);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/core/tsconfig-discovery.ts
+++ b/src/core/tsconfig-discovery.ts
@@ -9,6 +9,8 @@ const SKIP_DIRECTORIES = new Set([
 	"dist",
 	"build",
 	".git",
+	".claude",
+	".codex",
 	".next",
 	".turbo",
 	"coverage",


### PR DESCRIPTION
## Summary
- exclude nested `.claude` and `.codex` worktrees from TypeScript config discovery
- accept an explicit `tsconfig.json` path in similarity analysis
- suppress no-op naming findings and preserve Next.js App Router convention filenames

## Why
Resect's analysis of a large monorepo was producing avoidable noise and one misleading empty result:
- nested agent worktrees were counted as project configs
- `similar -p <tsconfig.json>` treated the config file as a directory and scanned zero files
- naming analysis suggested unchanged filenames and framework-invalid convention renames

## Testing
- `bun test src/core/tsconfig-discovery.test.ts src/core/similarity.test.ts src/commands/naming.test.ts` — 127 passed
- `pnpm typecheck`
- `bun x ultracite check`
- live monorepo smoke test: zero agent-worktree configs discovered; naming findings reduced from 83 to 13 with zero no-op or Next.js convention renames; similarity analysis scanned 3,668 files and 9,558 declarations

## Risk / rollout
Low risk. These changes only affect read-only analysis filtering and project-path resolution, with focused regression coverage. After release, watch discovery, naming, and similarity output for expected scoping.

## Screenshots / evidence
CLI and source-analysis change only; no visual changes.
