### PR TITLE
fix(cli): reject unsupported command options

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -19,4 +19,64 @@ describe("cli", () => {
 		await proc.exited;
 		expect(proc.exitCode).toBe(1);
 	});
+
+	test("rejects options unsupported by the selected command", async () => {
+		const outputPath = `/tmp/resect-discover-${crypto.randomUUID()}.json`;
+		const proc = Bun.spawn(
+			["bun", "src/cli.ts", "discover", ".", "--out", outputPath],
+			{ stderr: "pipe", stdout: "pipe" }
+		);
+		const [stderr, exitCode] = await Promise.all([
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("Error: --out is not supported by 'discover'");
+		expect(stderr).toContain("Run 'resect discover --help' for usage");
+		expect(await Bun.file(outputPath).exists()).toBe(false);
+	});
+
+	test("rejects mutation-only and short options on read-only commands", async () => {
+		const cases = [
+			{
+				args: ["discover", ".", "--force"],
+				expectedOption: "--force",
+			},
+			{
+				args: ["workspace", ".", "-p", "."],
+				expectedOption: "--project",
+			},
+		];
+
+		for (const { args, expectedOption } of cases) {
+			const proc = Bun.spawn(["bun", "src/cli.ts", ...args], {
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const [stderr, exitCode] = await Promise.all([
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+
+			expect(exitCode).toBe(1);
+			expect(stderr).toContain(
+				`Error: ${expectedOption} is not supported by '${args[0]}'`
+			);
+		}
+	});
+
+	test("keeps command help global when other options are present", async () => {
+		const proc = Bun.spawn(
+			["bun", "src/cli.ts", "discover", ".", "--force", "--help"],
+			{ stderr: "pipe", stdout: "pipe" }
+		);
+		const [stdout, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			proc.exited,
+		]);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("Usage: resect discover <directory> [options]");
+	});
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,11 @@ import { version } from "../package.json";
 import { logger } from "./cli-logger.ts";
 import { CLI_NAME, formatCommandList } from "./commands/command-spec.ts";
 import { applyResectConfigToCliValues } from "./commands/config-defaults.ts";
-import { PARSE_ARGS_OPTIONS, preprocessArgs } from "./commands/option-flags.ts";
+import {
+	findUnsupportedOptions,
+	PARSE_ARGS_OPTIONS,
+	preprocessArgs,
+} from "./commands/option-flags.ts";
 import type { CliValues } from "./commands/registry.ts";
 import { COMMANDS } from "./commands/registry.ts";
 import {
@@ -127,6 +131,22 @@ async function main() {
 	if (!cmd) {
 		logger.error(`Unknown command: ${command}`);
 		showHelp();
+		process.exit(1);
+	}
+
+	const unsupportedOptions = findUnsupportedOptions(
+		values as CliValues,
+		cmd.options
+	);
+	if (unsupportedOptions.length > 0) {
+		const formattedOptions = unsupportedOptions
+			.map((option) => `--${option}`)
+			.join(", ");
+		const verb = unsupportedOptions.length === 1 ? "is" : "are";
+		logger.error(
+			`Error: ${formattedOptions} ${verb} not supported by '${command}'`
+		);
+		logger.error(`Run '${CLI_NAME} ${command} --help' for usage`);
 		process.exit(1);
 	}
 

--- a/src/commands/command-spec.test.ts
+++ b/src/commands/command-spec.test.ts
@@ -5,6 +5,7 @@ import {
 	commandSpec,
 	formatCommandList,
 } from "./command-spec.ts";
+import { OPTION_FLAGS } from "./option-flags.ts";
 import { COMMANDS } from "./registry.ts";
 
 /**
@@ -106,6 +107,37 @@ describe("command prose derivation", () => {
 		// Every command's tool references mcpDescription("<name>").
 		for (const { name } of COMMAND_SPECS) {
 			expect(source).toContain(`description: mcpDescription("${name}")`);
+		}
+	});
+});
+
+describe("command option capabilities (#191)", () => {
+	test("every parsed command option is supported by at least one command", () => {
+		const globalOptions = new Set(["help", "version"]);
+		const parsedCommandOptions = new Set(
+			Object.keys(OPTION_FLAGS).filter((option) => !globalOptions.has(option))
+		);
+		const supportedOptions = new Set<string>(
+			COMMANDS.flatMap((command) => [...command.options])
+		);
+
+		expect(supportedOptions).toEqual(parsedCommandOptions);
+	});
+
+	test("each command documents exactly its supported options", () => {
+		for (const command of COMMANDS) {
+			const documentedOptions = new Set<string>();
+			for (const match of command.helpText.matchAll(
+				/^\s+(?:-[a-z],\s+)?--([a-z][a-z-]*)/gm
+			)) {
+				const option = match[1];
+				if (option) {
+					documentedOptions.add(option);
+				}
+			}
+
+			expect(new Set<string>(command.options)).toEqual(documentedOptions);
+			expect(new Set(command.options).size).toBe(command.options.length);
 		}
 	});
 });

--- a/src/commands/command-spec.ts
+++ b/src/commands/command-spec.ts
@@ -116,6 +116,7 @@ Arguments:
 
 Options:
   --verbose          Show detailed reference information
+  -p, --project      Path to project directory or tsconfig.json
   --workspace        Scan across all workspace packages
   --only-related-to  Filter referencedBy results to a file, folder, or glob pattern
 
@@ -147,7 +148,9 @@ Arguments:
   target    Proposed destination path
 
 Options:
-  --verbose    Show resolved source/target paths
+  -p, --project   Path to project directory or tsconfig.json
+  --workspace     Scan across all workspace packages
+  --verbose       Show resolved source/target paths
 
 Output includes:
   • Impacted files (direct + indirect importers)
@@ -304,6 +307,7 @@ Options:
   --json          Emit structured edits as JSON (use with --dry-run)
   --force         Allow operation when git worktree has uncommitted changes
   --journal       Record the applied operation for a later resect undo
+  --verify        Enable type checking verification, overriding project config
   --no-verify     Disable type checking verification (enabled by default)
   --verbose       Show detailed changes
   --workspace     Scan across all workspace packages
@@ -342,10 +346,12 @@ Arguments:
   target    Destination path for the file
 
 Options:
+  -p, --project     Path to project directory or tsconfig.json
   -n, --dry-run     Preview changes without modifying files
   --json            Emit structured edits as JSON (use with --dry-run)
   --force           Allow operation when git worktree has uncommitted changes
   --journal         Record the applied operation for a later resect undo
+  --verify          Enable type checking verification, overriding project config
   --no-verify       Disable type checking verification (enabled by default)
   --verbose         Show detailed information about each change
   --workspace       Scan across all workspace packages
@@ -394,12 +400,14 @@ Arguments:
   newName    New name for the export
 
 Options:
+  -p, --project   Path to project directory or tsconfig.json
   -n, --dry-run   Preview changes without modifying files
   --json          Emit structured edits as JSON (use with --dry-run)
   --force         Allow operation when git worktree has uncommitted changes
   --journal       Record the applied operation for a later resect undo
   --verbose       Show detailed information about each change
   --workspace     Scan across all workspace packages
+  --verify        Enable type checking verification, overriding project config
   --no-verify     Disable type checking verification (enabled by default)
 
 Features:
@@ -437,6 +445,7 @@ Options:
   -n, --dry-run   Preview the files that would be restored
   --force         Override unrelated or diverged-work safeguards
   --json          Output the structured undo result
+  --verify        Enable type checking verification, overriding project config
   --no-verify     Skip the post-undo typecheck
 
 Examples:
@@ -472,6 +481,7 @@ Options:
   --only-related-to Only show groups related to a file or folder (path or glob)
   --min-lines       Exclude declarations with fewer body lines (filters thin wrappers)
   --skip-directives Skip functions containing compile-time directives
+  --skip-wrappers   Skip thin wrapper functions (single return + call expression)
   --kinds           Comma-separated list of declaration kinds to include:
                     function, type, interface (default: all)
   --bucket          Filter groups by similarity bucket: exact, high, or medium
@@ -532,6 +542,7 @@ Options:
   --only-related-to  Only process groups related to a file or folder (path or glob)
   --min-lines        Exclude functions with fewer body lines (filters thin wrappers)
   --skip-directives  Skip functions containing compile-time directives
+  --skip-wrappers    Skip thin wrapper functions (single return + call expression)
   --name-threshold   Name similarity threshold 0.0–1.0 for filtering groups by function name
   --same-name-only   Only group functions with identical names
   --workspace        Scan across all workspace packages
@@ -580,6 +591,7 @@ Options:
   -n, --dry-run   Preview the locate + classify + codegen report; write nothing
   --force         Override the dirty-worktree guard and call-site conflict check
   --json          Output the result/report as JSON
+  --verbose       Show detailed information about each change
   -p, --project   Path to project directory or tsconfig.json
 
 Examples:
@@ -640,6 +652,7 @@ Options:
   -p, --project   Path to project directory or tsconfig.json
   --json          Output results as JSON
   --workspace     Scan across all workspace packages
+  --verbose       Show detailed output
 
 Findings:
   Sub-path export shadowing — files reachable through a barrel that ALSO have a
@@ -674,6 +687,7 @@ Arguments:
 Options:
   -n, --dry-run   Preview changes without modifying files
   --force         Allow operation when git worktree has uncommitted changes
+  --verify        Enable type checking verification, overriding project config
   --no-verify     Disable type checking verification (enabled by default)
   --verbose       Show detailed information about each change
   --json          Output results as JSON
@@ -745,10 +759,12 @@ Arguments:
   directory    Path to the project directory to scan
 
 Options:
+  -p, --project Path to project directory or tsconfig.json
   --json        Output results as JSON
   --fix         Remove orphan factory keys and run type checking
   -n, --dry-run Preview even when --fix is set
   --force       Allow --fix when the git worktree is dirty
+  --verify      Enable type checking verification, overriding project config
   --no-verify   Skip type checking verification (not recommended)
 
 Examples:
@@ -772,6 +788,9 @@ Arguments:
   directory    Path to the project directory to scan
 
 Options:
+  -p, --project              Path to project directory or tsconfig.json
+  --workspace                Scan across all workspace packages
+  --verbose                  Show detailed information about each change
   --json                    Output results as JSON
   --fix                     Move tests via the existing move pipeline
   -n, --dry-run             Preview even when --fix is set
@@ -799,6 +818,8 @@ Arguments:
   directory    Path to the project directory to scan
 
 Options:
+  -p, --project          Path to project directory or tsconfig.json
+  --verbose              Show detailed information about each change
   --json                  Output results as JSON
   --workspace             Scan across workspace packages
   --min-siblings          Minimum files in a directory before auditing (default: 3)
@@ -835,6 +856,7 @@ Arguments:
   directory    Path to the project directory to scan
 
 Options:
+  -p, --project Path to project directory or tsconfig.json
   --json        Output results as JSON
   --ignore      Glob pattern to exclude files (e.g. "*.generated.ts")
   --verbose     Show detailed output
@@ -866,6 +888,7 @@ Arguments:
   directory    Path to the project directory to scan
 
 Options:
+  -p, --project          Path to project directory or tsconfig.json
   --experimental         Required in 1.x to opt into the unstable tidy schema
   --json                 Output results as JSON
   --scope                Only show findings whose source file is under this path
@@ -873,12 +896,16 @@ Options:
   --workspace            Scan across all workspace packages where supported
   --fix                  Apply safe fixes (dead-exports, alias-normalisation)
   --fix=<categories>     Apply comma-separated tidy fix categories
+  --fix-category=<name>  Apply one tidy fix category (repeatable)
   -n, --dry-run         Plan selected fixes and emit their diffs without writing
   --alias-prefer=<s>     Alias-normalisation strategy: alias, relative, or shortest
   --max-changes          Abort --fix when planned changes exceed this limit (default: 50)
   --force                Allow --fix when the git worktree is dirty
   --journal              Record the applied fix batch for a later resect undo
   --verbose              Show extra operational messages
+  --fan-out-threshold    Flag files with more than N imports
+  --fan-in-threshold     Flag files with more than N consumers
+  --export-threshold     Flag files with more than N exports
 
 Examples:
   ${CLI_NAME} tidy src --experimental

--- a/src/commands/option-flags.test.ts
+++ b/src/commands/option-flags.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { parseArgs } from "node:util";
 import type { CliValues } from "./option-flags.ts";
 import {
+	findUnsupportedOptions,
 	OPTION_FLAGS,
 	PARSE_ARGS_OPTIONS,
 	preprocessArgs,
@@ -350,5 +351,32 @@ describe("preprocessArgs (#173)", () => {
 			"--",
 			"-n=false",
 		]);
+	});
+});
+
+describe("command option validation (#191)", () => {
+	test("accepts supported long, canonicalized short, and repeatable values", () => {
+		const { values } = parseArgs({
+			args: [
+				"-p",
+				"tsconfig.json",
+				"--rename-specifier=a=b",
+				"--rename-specifier=c=d",
+			],
+			options: PARSE_ARGS_OPTIONS,
+		});
+
+		expect(
+			findUnsupportedOptions(values as CliValues, [
+				"project",
+				"rename-specifier",
+			])
+		).toEqual([]);
+	});
+
+	test("reports every unsupported canonical option name", () => {
+		expect(
+			findUnsupportedOptions({ force: true, out: "report.json" }, ["verbose"])
+		).toEqual(["force", "out"]);
 	});
 });

--- a/src/commands/option-flags.ts
+++ b/src/commands/option-flags.ts
@@ -62,6 +62,9 @@ export const OPTION_FLAGS = {
 	batch: { type: "string" },
 } as const satisfies Record<string, FlagSpec>;
 
+/** A canonical long-form option name accepted by the CLI parser. */
+export type OptionName = keyof typeof OPTION_FLAGS;
+
 /** The exact object shape `parseArgs({ options })` expects. */
 export const PARSE_ARGS_OPTIONS = OPTION_FLAGS as NonNullable<
 	ParseArgsConfig["options"]
@@ -189,3 +192,14 @@ type DerivedCliValues = {
 export type CliValues = Omit<DerivedCliValues, "entrypoint-globs"> & {
 	"entrypoint-globs"?: string | string[];
 };
+
+/** Return explicitly supplied options that the selected command does not use. */
+export function findUnsupportedOptions(
+	values: CliValues,
+	supportedOptions: readonly OptionName[]
+): OptionName[] {
+	const supported = new Set<OptionName>(supportedOptions);
+	return (Object.keys(values) as OptionName[]).filter(
+		(option) => !supported.has(option)
+	);
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -22,7 +22,7 @@ import {
 	isInDomain,
 	PREFER_STRATEGIES,
 } from "./option-domains.ts";
-import type { CliValues } from "./option-flags.ts";
+import type { CliValues, OptionName } from "./option-flags.ts";
 
 export type { CliValues } from "./option-flags.ts";
 
@@ -49,6 +49,7 @@ function requireArg(
 interface CommandDef {
 	name: string;
 	helpText: string;
+	options: readonly OptionName[];
 	run: (args: string[], values: CliValues) => Promise<void> | void;
 }
 
@@ -56,6 +57,20 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "move",
 		helpText: cliHelp("move"),
+		options: [
+			"batch",
+			"dry-run",
+			"force",
+			"journal",
+			"json",
+			"verbose",
+			"verify",
+			"no-verify",
+			"project",
+			"workspace",
+			"transform",
+			"prefer",
+		],
 		run: async ([source, target], values) => {
 			if (values.batch && (source || target)) {
 				logger.error(
@@ -114,6 +129,17 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "rename",
 		helpText: cliHelp("rename"),
+		options: [
+			"dry-run",
+			"force",
+			"journal",
+			"json",
+			"verbose",
+			"project",
+			"workspace",
+			"verify",
+			"no-verify",
+		],
 		run: async ([file, oldName, newName], values) => {
 			if (!(file && oldName && newName)) {
 				logger.error(
@@ -141,6 +167,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "undo",
 		helpText: cliHelp("undo"),
+		options: ["dry-run", "force", "json", "project", "verify", "no-verify"],
 		run: async ([id], values) => {
 			await undoCommand({
 				id,
@@ -156,6 +183,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "analyze",
 		helpText: cliHelp("analyze"),
+		options: ["verbose", "project", "workspace", "only-related-to"],
 		run: async ([file], values) => {
 			requireArg("analyze", "<file>", file);
 			await analyzeCommand({
@@ -171,6 +199,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "analyze-impact",
 		helpText: cliHelp("analyze-impact"),
+		options: ["verbose", "project", "workspace"],
 		run: async ([source, target], values) => {
 			requireArg("analyze-impact", "<source>", source);
 			requireArg("analyze-impact", "<target>", target);
@@ -187,6 +216,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "affected",
 		helpText: cliHelp("affected"),
+		options: ["verbose", "project", "workspace", "json"],
 		run: async (files, values) => {
 			if (files.length === 0) {
 				logger.error("Error: affected requires at least one <file> argument");
@@ -206,6 +236,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "discover",
 		helpText: cliHelp("discover"),
+		options: ["verbose", "workspace", "only-related-to"],
 		run: async ([directory], values) => {
 			requireArg("discover", "<directory>", directory);
 			await discoverCommand({
@@ -220,6 +251,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "workspace",
 		helpText: cliHelp("workspace"),
+		options: ["verbose", "json"],
 		run: async ([directory], values) => {
 			requireArg("workspace", "<directory>", directory);
 			await workspaceCommand({
@@ -233,6 +265,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "deps",
 		helpText: cliHelp("deps"),
+		options: ["fix", "dry-run", "force", "strict", "json"],
 		run: async ([directory], values) => {
 			requireArg("deps", "<directory>", directory);
 			await depsCommand({
@@ -249,6 +282,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "find",
 		helpText: cliHelp("find"),
+		options: ["project", "type", "verbose", "workspace", "only-related-to"],
 		run: async ([query], values) => {
 			requireArg("find", "<query>", query);
 			if (!values.project) {
@@ -275,6 +309,19 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "alias",
 		helpText: cliHelp("alias"),
+		options: [
+			"prefer",
+			"rename-specifier",
+			"dry-run",
+			"force",
+			"journal",
+			"json",
+			"verbose",
+			"verify",
+			"no-verify",
+			"project",
+			"workspace",
+		],
 		run: async ([target], values) => {
 			requireArg("alias", "<target>", target);
 			const renameSpecifiers = values["rename-specifier"] ?? [];
@@ -309,6 +356,24 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "similar",
 		helpText: cliHelp("similar"),
+		options: [
+			"project",
+			"json",
+			"threshold",
+			"max-groups",
+			"strict",
+			"workspace",
+			"name-threshold",
+			"same-name-only",
+			"skip-same-file",
+			"only-related-to",
+			"min-lines",
+			"skip-directives",
+			"skip-wrappers",
+			"kinds",
+			"bucket",
+			"format",
+		],
 		run: async ([directory], values) => {
 			requireArg("similar", "<directory>", directory);
 			const rawThreshold = values.threshold;
@@ -385,6 +450,24 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "extract-common",
 		helpText: cliHelp("extract-common"),
+		options: [
+			"project",
+			"threshold",
+			"dry-run",
+			"force",
+			"json",
+			"strict",
+			"group",
+			"workspace",
+			"output",
+			"skip-same-file",
+			"only-related-to",
+			"min-lines",
+			"skip-directives",
+			"name-threshold",
+			"same-name-only",
+			"skip-wrappers",
+		],
 		run: async ([directory], values) => {
 			requireArg("extract-common", "<directory>", directory);
 			const rawThreshold = values.threshold;
@@ -423,6 +506,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "extract-component",
 		helpText: cliHelp("extract-component"),
+		options: ["json", "dry-run", "force", "verbose", "project"],
 		run: async ([file, selector, newFile], values) => {
 			if (!(file && selector && newFile)) {
 				logger.error(
@@ -447,6 +531,16 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "test-relocation",
 		helpText: cliHelp("test-relocation"),
+		options: [
+			"project",
+			"workspace",
+			"verbose",
+			"json",
+			"fix",
+			"dry-run",
+			"force",
+			"convention-threshold",
+		],
 		run: async ([directory], values) => {
 			requireArg("test-relocation", "<directory>", directory);
 			const rawConventionThreshold = values["convention-threshold"];
@@ -494,6 +588,15 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "mock-cleanup",
 		helpText: cliHelp("mock-cleanup"),
+		options: [
+			"project",
+			"json",
+			"fix",
+			"dry-run",
+			"force",
+			"verify",
+			"no-verify",
+		],
 		run: async ([directory], values) => {
 			requireArg("mock-cleanup", "<directory>", directory);
 			try {
@@ -516,6 +619,19 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "naming",
 		helpText: cliHelp("naming"),
+		options: [
+			"project",
+			"workspace",
+			"verbose",
+			"json",
+			"fix",
+			"force",
+			"dry-run",
+			"min-siblings",
+			"majority-threshold",
+			"case",
+			"include-tests",
+		],
 		run: async ([directory], values) => {
 			requireArg("naming", "<directory>", directory);
 			const rawMinSiblings = values["min-siblings"];
@@ -579,6 +695,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "organise",
 		helpText: cliHelp("organise"),
+		options: ["project", "json", "verbose", "ignore"],
 		run: async ([directory], values) => {
 			requireArg("organise", "<directory>", directory);
 			try {
@@ -599,6 +716,25 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "tidy",
 		helpText: cliHelp("tidy"),
+		options: [
+			"project",
+			"json",
+			"workspace",
+			"verbose",
+			"experimental",
+			"scope",
+			"out",
+			"fix",
+			"dry-run",
+			"fix-category",
+			"alias-prefer",
+			"force",
+			"journal",
+			"max-changes",
+			"fan-out-threshold",
+			"fan-in-threshold",
+			"export-threshold",
+		],
 		run: async ([directory], values) => {
 			requireArg("tidy", "<directory>", directory);
 			try {
@@ -662,6 +798,14 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "audit",
 		helpText: cliHelp("audit"),
+		options: [
+			"project",
+			"json",
+			"workspace",
+			"fan-out-threshold",
+			"fan-in-threshold",
+			"export-threshold",
+		],
 		run: async ([directory], values) => {
 			requireArg("audit", "<directory>", directory);
 			await auditCommand({
@@ -685,6 +829,14 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "unused",
 		helpText: cliHelp("unused"),
+		options: [
+			"project",
+			"json",
+			"verbose",
+			"ignore",
+			"workspace",
+			"entrypoint-globs",
+		],
 		run: async ([directory], values) => {
 			requireArg("unused", "<directory>", directory);
 			const { unusedCommand: cmd } = await import("./unused.ts");
@@ -703,6 +855,7 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "barrel",
 		helpText: cliHelp("barrel"),
+		options: ["project", "json", "workspace", "verbose"],
 		run: async ([directory], values) => {
 			requireArg("barrel", "<directory>", directory);
 			try {
@@ -723,6 +876,15 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "inline",
 		helpText: cliHelp("inline"),
+		options: [
+			"dry-run",
+			"force",
+			"verbose",
+			"verify",
+			"no-verify",
+			"project",
+			"json",
+		],
 		run: async ([barrelFile], values) => {
 			requireArg("inline", "<barrel-file>", barrelFile);
 			await inlineCommand({


### PR DESCRIPTION
## Summary

- reject explicit CLI options that the selected command does not support
- declare a typed option-capability list beside every command handler
- keep command help aligned with those capabilities through drift tests

## Why

The global parser recognized every CLI option for every command, so unsupported options such as `resect discover . --out report.json` were silently ignored with a successful exit. This makes the selected command validate explicit options before project-config defaults are applied, while preserving global `--help` and `--version` behavior.

Closes #191

## Testing

- `pnpm run fix`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run typecheck`
- focused CLI, option, config, help, and representative command suites: 109 passed, 0 failed
- `bun test --timeout=20000`: 927 passed, 0 failed across 68 files
- pre-commit affected suite: 85 passed, 0 failed; similarity, build, global reinstall, and formatting gates passed

## Risk / Rollout

Low. Commands now fail fast for flags they previously ignored. Existing supported long, short, and repeatable options remain accepted; config-provided defaults are applied after explicit-argument validation.

## Screenshots / Evidence

Not applicable; this is CLI behavior with automated regression coverage.
