### PR TITLE
fix(analysis): exclude Next-generated type artifacts

### DIFF
--- a/.requirements-status.json
+++ b/.requirements-status.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "projectId": "mherod/resect",
   "requirementsFile": "REQUIREMENTS.md",
-  "requirementsSha256": "dd3646b9336e134396b9929e3832f2df844ad4852f251c8b34473135c080844d",
-  "sourceCommit": "10a2b3b74d778315a945393430b56139188318d5",
-  "generatedAt": "2026-08-07T16:28:47Z",
+  "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
+  "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
+  "generatedAt": "2026-08-08T04:17:43Z",
   "validator": {
     "name": "generate-requirements",
     "version": "2.0.0",
@@ -13,15 +13,15 @@
   "validation": {
     "structure": {
       "status": "PASS",
-      "receiptId": "STRUCT-20260807-001",
+      "receiptId": "STRUCT-20260808-001",
       "validator": "validate-bdd",
       "validatorVersion": "2.0.0",
       "command": "bun $HOME/.agents/skills/generate-requirements/scripts/validate-bdd.js REQUIREMENTS.md --status-log .requirements-status.json",
-      "requirementsSha256": "dd3646b9336e134396b9929e3832f2df844ad4852f251c8b34473135c080844d",
-      "sourceCommit": "10a2b3b74d778315a945393430b56139188318d5",
-      "generatedAt": "2026-08-07T16:11:07Z",
+      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
+      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
+      "generatedAt": "2026-08-08T04:17:43Z",
       "counts": {
-        "checked": 36,
+        "checked": 38,
         "errors": 0,
         "warnings": 0
       },
@@ -31,41 +31,41 @@
     },
     "documentQuality": {
       "status": "PASS",
-      "receiptId": "QUALITY-20260807-001",
+      "receiptId": "QUALITY-20260808-001",
       "validator": "generate-requirements-manual-review",
       "validatorVersion": "2.0.0",
       "command": "generate-requirements 2.0 manual review of REQUIREMENTS.md",
-      "requirementsSha256": "dd3646b9336e134396b9929e3832f2df844ad4852f251c8b34473135c080844d",
-      "sourceCommit": "10a2b3b74d778315a945393430b56139188318d5",
-      "generatedAt": "2026-08-07T16:11:07Z",
+      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
+      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
+      "generatedAt": "2026-08-08T04:17:43Z",
       "counts": {
-        "checked": 36,
+        "checked": 38,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "Reviewed all 36 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
-        "Journal retention, guarded undo, user-initiated reversibility, and public-surface parity are explicit; no preamble or priority-skew warning was computed."
+        "Reviewed all 38 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
+        "Framework-generated exclusions are explicit across the shared analysis actor group, default and configured Next output boundaries, human and machine-readable results, and authored declaration preservation; no preamble or priority-skew warning was computed."
       ]
     },
     "implementation": {
       "status": "PASS",
-      "receiptId": "IMPL-20260807-001",
+      "receiptId": "IMPL-20260808-001",
       "validator": "bun-test-plus-clause-audit",
       "validatorVersion": "1.3.14+generate-requirements-2.0.0",
-      "command": "bun test src/core/journal.test.ts src/core/git.test.ts src/commands/undo.test.ts src/commands/journal-integration.test.ts src/commands/option-flags.test.ts src/commands/command-spec.test.ts src/mcp-schema-parity.test.ts --timeout=20000 --parallel=4 && ./node_modules/.bin/biome check --no-errors-on-unmatched . && ./node_modules/.bin/eslint src --max-warnings 0 && bun x tsc --noEmit",
-      "requirementsSha256": "dd3646b9336e134396b9929e3832f2df844ad4852f251c8b34473135c080844d",
-      "sourceCommit": "10a2b3b74d778315a945393430b56139188318d5",
-      "generatedAt": "2026-08-07T16:28:47Z",
+      "command": "bun test src/core/generated-artifacts.test.ts src/commands/audit.test.ts src/commands/naming.test.ts src/commands/unused.test.ts src/mcp-schema-parity.test.ts src/index.test.ts --timeout=20000 --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
+      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
+      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
+      "generatedAt": "2026-08-08T04:17:43Z",
       "counts": {
-        "checked": 36,
+        "checked": 38,
         "errors": 0,
-        "warnings": 1
+        "warnings": 0
       },
       "notes": [
-        "The journal, undo, CLI integration, command roster, option flag, Git guard, and MCP parity focus passed 67 tests with 0 failures and 424 assertions; Biome, ESLint, and TypeScript checks also passed against the audited worktree.",
-        "The complete bare Bun suite passed 914 tests with 0 failures and 2483 assertions across 67 files after making subprocess access to the local tsc binary explicit and correcting extension removal for resolved paths whose parent directories contain dots.",
-        "The exact pnpm scripts and configured tarball-size preflight could not run because Corepack timed out against the configured internal registry; installed local check equivalents were used without changing registry policy.",
+        "The generated-artifact, audit, naming, unused, MCP parity, and library focus passed 115 tests with 0 failures and 390 assertions across 6 files.",
+        "The complete Bun suite passed 933 tests with 0 failures and 2594 assertions across 69 files; the guarded commit additionally passed 702 affected tests with 0 failures and 2214 assertions across 55 files.",
+        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed against source commit 7016141.",
         "MOVE-001 through MOVE-003 map to src/commands/move.test.ts and src/commands/move.ts at source commit 52106e7.",
         "TIDY-001, TIDY-002, and ROLL-001 map to src/commands/tidy.test.ts, src/core/rollback.test.ts, src/commands/tidy.ts, and src/core/rollback.ts at source commit 52106e7.",
         "CFG-001 through CFG-006 map to src/core/project-config.test.ts, src/commands/config-defaults.test.ts, src/commands/discover.test.ts, and their corresponding implementation files at source commit 52106e7.",
@@ -76,32 +76,33 @@
         "AUDIT-001 through AUDIT-004 map to src/commands/audit.test.ts, src/commands/audit.ts, and src/mcp-server.ts at source commit 52106e7.",
         "NAM-001 through NAM-003 map to src/commands/naming.test.ts, src/commands/naming.ts, src/commands/registry.ts, src/mcp-server.ts, src/types/naming.ts, and src/index.test.ts; 50 focused tests passed with 0 failures and 154 assertions.",
         "JOUR-001 and JOUR-002 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/journal-integration.test.ts, the move, rename, alias, tidy, MCP, registry, and library surfaces.",
-        "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts."
+        "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts.",
+        "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit 7016141."
       ]
     }
   },
   "metrics": {
-    "totalScenarios": 36,
+    "totalScenarios": 38,
     "byDelivery": {
-      "V1": 36,
+      "V1": 38,
       "V2": 0,
       "LATER": 0,
       "UNSLICED": 0
     },
     "byDecision": {
-      "DECIDED": 36,
+      "DECIDED": 38,
       "OPEN": 0
     },
     "byPriority": {
       "P0": 4,
-      "P1": 20,
+      "P1": 22,
       "P2": 12,
       "P3": 0
     },
     "priorityByDelivery": {
       "V1": {
         "P0": 4,
-        "P1": 20,
+        "P1": 22,
         "P2": 12,
         "P3": 0
       },
@@ -125,15 +126,15 @@
       }
     },
     "byFidelity": {
-      "VERIFIED": 36,
+      "VERIFIED": 38,
       "DRIFTED": 0,
       "MISSING": 0,
       "UNTESTABLE": 0
     },
     "coverage": {
       "v1Decided": {
-        "eligible": 36,
-        "verified": 36,
+        "eligible": 38,
+        "verified": 38,
         "percentage": 100
       },
       "v1LaunchCritical": {
@@ -175,8 +176,8 @@
     "fidelityNoteMismatchIds": [],
     "orphanAnchorIds": [],
     "preamble": {
-      "linesBeforeFirstScenario": 102,
-      "percentageBeforeFirstScenario": 23.3,
+      "linesBeforeFirstScenario": 104,
+      "percentageBeforeFirstScenario": 22.6,
       "warning": false,
       "disposition": null
     },

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -3,13 +3,13 @@
 ## Document Contract
 
 - Contract version: 2.0
-- Last updated: 2026-08-07
+- Last updated: 2026-08-08
 - Requirements owner: Repository owner
 - Canonical artifact: `REQUIREMENTS.md`; derived review evidence: `.requirements-status.json`
 
 ## Product Ground Truth
 
-Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, and source-focused audit metrics. Other commands remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
+Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, and source-focused read-only analysis. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
 
 ## Source Register
 
@@ -26,12 +26,13 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | SRC-009 | Repository owner issue | 2026-06-10 | https://github.com/mherod/resect/issues/147 | Transform config execution risk, documentation, and pre-execution warning |
 | SRC-010 | Repository owner issue | 2026-07-11 | https://github.com/mherod/resect/issues/162 | Explicit filename-casing audit, surface parity, warning, and fix behavior |
 | SRC-011 | Repository owner issue | 2026-08-05 re-grounding | https://github.com/mherod/resect/issues/134 | Opt-in operation journal, guarded user-initiated undo, retention cap, and public-surface parity |
+| SRC-012 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/190 | Framework-generated TypeScript exclusion across audit, naming, and unused analysis |
 
 ## Delivery and Decision Register
 
 | Decision ID | Decision | State | Delivery | Sources | Reversal condition |
 |---|---|---|---|---|---|
-| DR-001 | This baseline covers the ten accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011 | A repository-owner decision expands or retires the baseline. |
+| DR-001 | This baseline covers the eleven accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012 | A repository-owner decision expands or retires the baseline. |
 | DR-002 | Resect is a local developer tool without accounts, tenants, sessions, notifications, analytics, or media. | DECIDED | V1 | SRC-007 | A published contract adds one of these product surfaces. |
 | DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009 | The execution model moves into a managed remote sandbox. |
 | DR-004 | Batch moves are sequential within one process and use one setup, worktree guard, and verification boundary. | DECIDED | V1 | SRC-006 | A repository-owner decision introduces parallel or cross-process coordination. |
@@ -42,8 +43,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Actor | Access scope and capabilities | Limitation and direct-attempt coverage | Passive perspective |
 |---|---|---|---|
-| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, and unsafe undo attempts are refused or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004. | Resolved configuration, previews, journal identifiers, target-casing findings, and source-focused audit metrics are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, AUDIT-001, AUDIT-002, AUDIT-003. |
-| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, target-casing findings, and audit exclusions are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, AUDIT-004. |
+| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, and unsafe undo attempts are refused or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004. | Resolved configuration, previews, journal identifiers, target-casing findings, source-focused metrics, and generated-artifact exclusions are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002. |
+| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, target-casing findings, audit exclusions, and generated-artifact exclusions are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, AUDIT-004, ANLY-001, ANLY-002. |
 
 ## Actor Groups
 
@@ -51,6 +52,7 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 |---|---|---|
 | Transform Config Consumer | Operator; API Consumer | Callers that do not request a transform config |
 | Naming Consumer | Operator; API Consumer | Callers that do not invoke the naming surface |
+| Analysis Consumer | Operator; API Consumer | Callers that do not invoke audit, naming, or unused analysis |
 | Refactor Consumer | Operator; API Consumer | Callers that do not invoke the CLI, MCP, or library refactoring surfaces |
 
 ## V1 Launch Critical Path
@@ -65,7 +67,7 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Coverage row | Scenario IDs or N/A | Decision or rationale |
 |---|---|---|
 | Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001 | Journal, configuration, transform, batch, and target-casing entry points are explicit. |
-| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or audit output. |
+| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
 | Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002 | Successful mutations and reversals report the applied operation. |
 | Cancel or alternative exit | UNDO-003, BATCH-001 | Dry-run is the non-mutating alternative. |
 | Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007 | Failure paths preserve truthful outcomes. |
@@ -88,14 +90,14 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Security, session expiry or revocation, and abuse | APPLIES | TRNS-003 | Transform configs execute with host process privileges, so the consumer is warned before execution; SRC-009, DR-003. |
 | Audit and accountability | APPLIES | JOUR-001 | An opt-in local operation history identifies the command, inputs, timestamp, and affected files; SRC-011, DR-006. |
 | Notifications and communication preferences | N/A | — | No notification channel or preference model; DR-002; XC-NA-005. |
-| Search and discovery | APPLIES | CFG-001, CFG-005, AUDIT-001 | Project configuration and configured source or output boundaries are discovered and applied. |
+| Search and discovery | APPLIES | CFG-001, CFG-005, AUDIT-001, ANLY-001 | Project configuration and configured source, output, or framework-generated boundaries are discovered and applied. |
 | Empty and first-run states | APPLIES | UNDO-005, CFG-006, BATCH-005, BATCH-007 | Missing undo history and config are handled explicitly, and empty batches are rejected. |
 | Limits, quotas, and upgrade or denial behavior | APPLIES | JOUR-002 | Local operation history has a fixed retention limit without a plan or upgrade model; DR-006. |
 | Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004 | Mutating and reversal failures report truthfully and preserve later work unless explicitly forced. |
 | Persistence, interruption, and re-entry | APPLIES | JOUR-001, UNDO-001, UNDO-002, TIDY-002, ROLL-001 | Journal entries persist across command invocations and support a later guarded reversal. |
 | Data lifecycle, retention, deletion, and export | APPLIES | JOUR-002 | Operation history retains only the newest 20 entries; SRC-011, DR-006. |
 | Analytics and telemetry | N/A | — | No analytics or telemetry surface in baseline; DR-002; XC-NA-008. |
-| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, AUDIT-001, AUDIT-002, AUDIT-003 | Config and graph state are refreshed at their documented boundaries, and audit metrics represent authored sources rather than duplicate build artifacts. |
+| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001 | Config and graph state are refreshed at their documented boundaries, and read-only analysis represents authored sources rather than framework-generated artifacts. |
 | Media alternatives, captions, transcripts, and reduced motion | N/A | — | No media or motion surface; DR-002; XC-NA-009. |
 
 ## Feature: Safe Refactor Mutation and Rollback
@@ -425,12 +427,33 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 **Then** each excluded generated file identifies its project and output boundary
 **And** an unambiguous authored source counterpart is identified when available
 
+## Feature: Framework-Generated Analysis Scope
+
+### ANLY-001 — Analysis Consumer — Exclude Next-generated type artifacts from source analysis
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-012
+
+**Given** a project contains Next-generated type artifacts under its default or configured output directory and an authored declaration elsewhere
+**When** an Analysis Consumer runs a supported read-only source analysis
+**Then** the framework-generated artifacts are absent from audit, naming, and unused findings
+**And** the authored declaration remains analyzable
+
+### ANLY-002 — Analysis Consumer — Inspect framework-generated exclusions
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-012
+
+**Given** a supported read-only source analysis excludes framework-generated artifacts
+**When** the Analysis Consumer receives the result
+**Then** the result reports the number of excluded artifacts
+**And** a warning explains that framework-generated TypeScript was excluded
+**And** a machine-readable result identifies the excluded paths
+
 ## Validation Receipts
 
 | Layer | Status | Receipt | Current artifact |
 |---|---|---|---|
-| Structure | PASS | STRUCT-20260805-002 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
-| Document quality | PASS | QUALITY-20260805-002 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
-| Implementation | PASS | IMPL-20260805-002 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
+| Structure | PASS | STRUCT-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
+| Document quality | PASS | QUALITY-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
+| Implementation | PASS | IMPL-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
 
 The canonical validator, manual product-contract review, and focused implementation audit are independent. Counts, hashes, source commit, commands, timestamps, warning dispositions, and evidence summaries live only in the derived status artifact.

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -269,6 +269,69 @@ describe("buildAuditReport", () => {
 });
 
 describe("audit command coverage", () => {
+	// @BDD: ANLY-001-Verified
+	// @BDD: ANLY-002-Verified
+	test("excludes Next-generated declarations and reports the shared warning", async () => {
+		const dir = await makeFixture("audit-next-generated", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true },
+				include: [
+					"app/**/*.tsx",
+					"types/**/*.d.ts",
+					".next/types/**/*.ts",
+					".next/dev/types/**/*.ts",
+				],
+			}),
+			"app/page.tsx": "export const pageValue = 1;\n",
+			"types/authored.d.ts": "export interface AuthoredValue { id: string }\n",
+			".next/types/cache-life.d.ts":
+				"export declare const generatedCache: string;\n",
+			".next/dev/types/route-metadata.d.ts":
+				"export declare const generatedRoute: string;\n",
+		});
+
+		try {
+			const jsonProc = Bun.spawn(
+				[...CLI, "audit", dir, "--json", "--export-threshold", "0"],
+				{ stdout: "pipe", stderr: "pipe" }
+			);
+			const [stdout, stderr] = await Promise.all([
+				new Response(jsonProc.stdout).text(),
+				new Response(jsonProc.stderr).text(),
+			]);
+			await jsonProc.exited;
+			expect(jsonProc.exitCode, stderr).toBe(0);
+			const report = JSON.parse(stdout);
+			expect(report.excludedGeneratedFileCount).toBe(2);
+			expect(
+				report.excludedGeneratedFiles.map(({ file }: { file: string }) => file)
+			).toEqual([
+				".next/dev/types/route-metadata.d.ts",
+				".next/types/cache-life.d.ts",
+			]);
+			expect(report.warnings).toContain(
+				"Excluded 2 framework-generated TypeScript file(s) from analysis."
+			);
+			expect(report.largeExportSurface).toContainEqual(
+				expect.objectContaining({ file: "types/authored.d.ts" })
+			);
+
+			const humanProc = Bun.spawn([...CLI, "audit", dir], {
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			await new Response(humanProc.stdout).text();
+			const humanStderr = await new Response(humanProc.stderr).text();
+			await humanProc.exited;
+			expect(humanProc.exitCode).toBe(0);
+			expect(humanStderr).toContain(
+				"Excluded 2 framework-generated TypeScript file(s) from analysis."
+			);
+		} finally {
+			await cleanup(dir);
+		}
+	});
+
 	test("excludes imported outDir declarations while retaining authored declarations", async () => {
 		const dir = await makeFixture("audit-generated-output", {
 			"package.json": JSON.stringify({

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -2,6 +2,13 @@ import path from "node:path";
 import { logger } from "../cli-logger.ts";
 import { removeExtension } from "../core/constants.ts";
 import {
+	createFrameworkGeneratedArtifactClassifier,
+	excludeFrameworkGeneratedArtifacts,
+	type FrameworkGeneratedArtifact,
+	type FrameworkGeneratedArtifactClassifier,
+	generatedArtifactWarning,
+} from "../core/generated-artifacts.ts";
+import {
 	type DependencyGraph,
 	mergeDependencyGraphs,
 	withGraphSourceFile,
@@ -40,6 +47,7 @@ export interface AuditReport {
 	totalFiles: number;
 	skippedFiles: string[];
 	excludedGeneratedFiles: ExcludedGeneratedFile[];
+	excludedFrameworkGeneratedFiles: FrameworkGeneratedArtifact[];
 	metrics: FileMetrics[];
 	cycles: Cycle[];
 	highFanOut: FileMetrics[];
@@ -74,6 +82,7 @@ export interface AuditJsonReport {
 	skippedFileCount: number;
 	skippedFiles: string[];
 	totalFiles: number;
+	warnings: string[];
 }
 
 interface AuditProjectBoundary {
@@ -248,14 +257,13 @@ const projectAuditGraph = (
 
 const prepareAuditGraph = (
 	graph: DependencyGraph,
-	projectGraphs: AuditProjectGraph[]
+	projectGraphs: AuditProjectGraph[],
+	frameworkClassifier?: FrameworkGeneratedArtifactClassifier
 ): {
 	excludedGeneratedFiles: ExcludedGeneratedFile[];
+	excludedFrameworkGeneratedFiles: FrameworkGeneratedArtifact[];
 	graph: DependencyGraph;
 } => {
-	if (projectGraphs.length === 0) {
-		return { excludedGeneratedFiles: [], graph };
-	}
 	const boundaries = projectGraphs.map(({ project }) =>
 		projectBoundary(project)
 	);
@@ -268,11 +276,31 @@ const prepareAuditGraph = (
 			excludedByFile.set(excluded.file, excluded);
 		}
 	}
+	const compilerFilteredGraph =
+		projected.length > 0
+			? mergeDependencyGraphs(projected.map((item) => item.graph))
+			: graph;
+	const frameworkFiltered = frameworkClassifier
+		? excludeFrameworkGeneratedArtifacts(
+				compilerFilteredGraph,
+				frameworkClassifier
+			)
+		: { graph: compilerFilteredGraph, excludedGeneratedFiles: [] };
+	for (const artifact of frameworkFiltered.excludedGeneratedFiles) {
+		if (!excludedByFile.has(artifact.file)) {
+			excludedByFile.set(artifact.file, {
+				file: artifact.file,
+				outDir: artifact.generatedDirectory,
+				tsconfigPath: artifact.tsconfigPath,
+			});
+		}
+	}
 	return {
 		excludedGeneratedFiles: [...excludedByFile.values()].sort((a, b) =>
 			a.file.localeCompare(b.file)
 		),
-		graph: mergeDependencyGraphs(projected.map((item) => item.graph)),
+		excludedFrameworkGeneratedFiles: frameworkFiltered.excludedGeneratedFiles,
+		graph: frameworkFiltered.graph,
 	};
 };
 
@@ -424,9 +452,10 @@ export function buildAuditReport(
 		fanInThreshold: number;
 		exportThreshold: number;
 	},
-	projectGraphs: AuditProjectGraph[] = []
+	projectGraphs: AuditProjectGraph[] = [],
+	frameworkClassifier?: FrameworkGeneratedArtifactClassifier
 ): AuditReport {
-	const prepared = prepareAuditGraph(graph, projectGraphs);
+	const prepared = prepareAuditGraph(graph, projectGraphs, frameworkClassifier);
 	const metrics = computeMetrics(prepared.graph);
 	const cycles = detectCycles(prepared.graph);
 
@@ -440,6 +469,7 @@ export function buildAuditReport(
 		totalFiles: metrics.length,
 		skippedFiles: prepared.graph.skippedFiles,
 		excludedGeneratedFiles: prepared.excludedGeneratedFiles,
+		excludedFrameworkGeneratedFiles: prepared.excludedFrameworkGeneratedFiles,
 		metrics,
 		cycles,
 		highFanOut,
@@ -456,6 +486,14 @@ export function auditReportToJson(
 		...metric,
 		file: path.relative(baseDir, metric.file),
 	});
+	const warnings =
+		report.excludedFrameworkGeneratedFiles.length > 0
+			? [
+					generatedArtifactWarning(
+						report.excludedFrameworkGeneratedFiles.length
+					),
+				]
+			: [];
 	return {
 		totalFiles: report.totalFiles,
 		skippedFileCount: report.skippedFiles.length,
@@ -477,6 +515,7 @@ export function auditReportToJson(
 		highFanOut: report.highFanOut.map(relativeMetric),
 		highFanIn: report.highFanIn.map(relativeMetric),
 		largeExportSurface: report.largeExportSurface.map(relativeMetric),
+		warnings,
 	};
 }
 
@@ -520,6 +559,9 @@ export async function auditCommand(options: AuditOptions): Promise<void> {
 		const project = projectsByConfig.get(normalizePath(item.tsconfigPath));
 		return project ? [{ graph: item.graph, project }] : [];
 	});
+	const frameworkClassifier = await createFrameworkGeneratedArtifactClassifier(
+		context.graphs.map(({ tsconfigPath }) => tsconfigPath)
+	);
 	const report = buildAuditReport(
 		graph,
 		{
@@ -527,7 +569,8 @@ export async function auditCommand(options: AuditOptions): Promise<void> {
 			fanInThreshold,
 			exportThreshold,
 		},
-		projectGraphs
+		projectGraphs,
+		frameworkClassifier
 	);
 
 	if (json) {
@@ -553,6 +596,13 @@ function printReport(
 	}
 ): void {
 	logger.info(`\n📊 Module Health Report (${report.totalFiles} files)\n`);
+
+	if (report.excludedFrameworkGeneratedFiles.length > 0) {
+		logger.warn(
+			`⚠️  ${generatedArtifactWarning(report.excludedFrameworkGeneratedFiles.length)}`
+		);
+		logger.empty();
+	}
 
 	if (report.skippedFiles.length > 0) {
 		logger.warn(

--- a/src/commands/naming.test.ts
+++ b/src/commands/naming.test.ts
@@ -269,6 +269,54 @@ describe("naming command", () => {
 		await cleanup(dir);
 	});
 
+	// @BDD: ANLY-001-Verified
+	// @BDD: ANLY-002-Verified
+	test("excludes a custom Next distDir while retaining authored declarations", async () => {
+		const dir = await makeFixture("next-generated", {
+			"next.config.mjs": "export default { distDir: 'next-build' };\n",
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true },
+				include: [
+					"types/**/*.d.ts",
+					"next-build/types/**/*.ts",
+					"next-build/dev/types/**/*.ts",
+				],
+			}),
+			"types/Authored_Name.d.ts":
+				"export interface AuthoredName { id: string }\n",
+			"next-build/types/cache-life.d.ts":
+				"export declare const cacheLife: string;\n",
+			"next-build/dev/types/route-metadata.d.ts":
+				"export declare const routeMetadata: string;\n",
+		});
+
+		const jsonResult = await captureOutput(async () => {
+			await namingCommand({ directory: dir, case: "camelCase", json: true });
+		});
+		const report = JSON.parse(jsonResult.stdout);
+		expect(report.summary.totalFiles).toBe(1);
+		expect(report.summary.excludedGeneratedFileCount).toBe(2);
+		expect(report.excludedGeneratedFiles).toEqual([
+			"next-build/dev/types/route-metadata.d.ts",
+			"next-build/types/cache-life.d.ts",
+		]);
+		expect(report.findings).toEqual([
+			expect.objectContaining({ file: "types/Authored_Name.d.ts" }),
+		]);
+		expect(report.warnings).toContain(
+			"Excluded 2 framework-generated TypeScript file(s) from analysis."
+		);
+
+		const humanResult = await captureOutput(async () => {
+			await namingCommand({ directory: dir, case: "camelCase" });
+		});
+		expect(humanResult.stdout).toContain(
+			"Excluded 2 framework-generated TypeScript file(s) from analysis."
+		);
+
+		await cleanup(dir);
+	});
+
 	test("NAM-003: --case warns that --majority-threshold is ignored", async () => {
 		const dir = await makeFixture("target-warning", {
 			"src/group/BuildReport.ts": functionFile("BuildReport"),

--- a/src/commands/naming.ts
+++ b/src/commands/naming.ts
@@ -4,6 +4,11 @@ import { logger } from "../cli-logger.ts";
 import { hasDefaultModifier, hasExportModifier } from "../core/ast-utils.ts";
 import { TS_JS_VUE_EXTENSIONS } from "../core/constants.ts";
 import { isFrameworkConventionFile } from "../core/framework-conventions.ts";
+import {
+	createFrameworkGeneratedArtifactClassifier,
+	excludeFrameworkGeneratedArtifacts,
+	generatedArtifactWarning,
+} from "../core/generated-artifacts.ts";
 import { ensureCleanWorktree, rollbackMoves } from "../core/git.ts";
 import {
 	type DependencyGraph,
@@ -629,7 +634,14 @@ export async function buildNamingReport(
 		project: options.project,
 		workspace: options.workspace,
 	});
-	const graph = mergeDependencyGraphs(graphs.map(({ graph: g }) => g));
+	const frameworkClassifier = await createFrameworkGeneratedArtifactClassifier(
+		graphs.map(({ tsconfigPath: configPath }) => configPath)
+	);
+	const preparedGraph = excludeFrameworkGeneratedArtifacts(
+		mergeDependencyGraphs(graphs.map(({ graph: itemGraph }) => itemGraph)),
+		frameworkClassifier
+	);
+	const graph = preparedGraph.graph;
 	const minSiblings = options.minSiblings ?? DEFAULT_MIN_SIBLINGS;
 	const majorityThreshold =
 		options.majorityThreshold ?? DEFAULT_MAJORITY_THRESHOLD;
@@ -640,16 +652,24 @@ export async function buildNamingReport(
 		case: options.case,
 		includeTests: options.includeTests,
 	});
-	const warnings =
+	const warnings: string[] =
 		options.case && options.majorityThreshold !== undefined
 			? [TARGET_CASE_THRESHOLD_WARNING]
 			: [];
+	if (preparedGraph.excludedGeneratedFiles.length > 0) {
+		warnings.push(
+			generatedArtifactWarning(preparedGraph.excludedGeneratedFiles.length)
+		);
+	}
 
 	return {
 		schemaVersion: NAMING_SCHEMA_VERSION,
 		directory: toRelativePath(process.cwd(), reportDirectory),
 		generatedAt: new Date().toISOString(),
 		warnings,
+		excludedGeneratedFiles: preparedGraph.excludedGeneratedFiles.map(
+			({ file }) => toRelativePath(reportDirectory, file)
+		),
 		findings: analysis.violations.map((violation) =>
 			relativizeViolation(violation, reportDirectory)
 		),
@@ -657,6 +677,7 @@ export async function buildNamingReport(
 			totalFindings: analysis.violations.length,
 			filesTouched: 0,
 			totalFiles: analysis.totalFiles,
+			excludedGeneratedFileCount: preparedGraph.excludedGeneratedFiles.length,
 			totalDirectories: analysis.totalDirectories,
 			minSiblings,
 			majorityThreshold,
@@ -676,6 +697,13 @@ export function formatNamingReport(report: NamingReport): string {
 		`Rules: ${rule}`,
 		"",
 	];
+	if (report.warnings.length > 0) {
+		lines.push("Warnings:");
+		for (const warning of report.warnings) {
+			lines.push(`  - ${warning}`);
+		}
+		lines.push("");
+	}
 	const groups = groupByFileDirectory(report.findings);
 	if (report.findings.length === 0) {
 		lines.push("No naming convention outliers found.");

--- a/src/commands/unused.test.ts
+++ b/src/commands/unused.test.ts
@@ -35,6 +35,75 @@ describe("unused command", () => {
 		expect(serverSource).toContain(
 			"coverageIncomplete: report.skippedFiles.length > 0"
 		);
+		expect(serverSource).toContain(
+			"excludedGeneratedFileCount: report.excludedGeneratedFileCount"
+		);
+		expect(serverSource).toContain(
+			"excludedGeneratedFiles: report.excludedGeneratedFiles.map"
+		);
+	});
+
+	// @BDD: ANLY-001-Verified
+	// @BDD: ANLY-002-Verified
+	test("excludes default Next type artifacts while retaining authored declarations", async () => {
+		const dir = await makeFixtureBase(
+			"unused-next-generated",
+			{
+				"tsconfig.json": JSON.stringify({
+					compilerOptions: { strict: true },
+					include: [
+						"types/**/*.d.ts",
+						".next/types/**/*.ts",
+						".next/dev/types/**/*.ts",
+					],
+				}),
+				"types/authored.d.ts":
+					"export interface AuthoredValue { id: string }\n",
+				".next/types/cache-life.d.ts":
+					"export declare const generatedCache: string;\n",
+				".next/dev/types/route-metadata.d.ts":
+					"export declare const generatedRoute: string;\n",
+			},
+			{ outsideRepo: true }
+		);
+
+		const jsonProc = Bun.spawn([...CLI, "unused", dir, "--json"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr] = await Promise.all([
+			new Response(jsonProc.stdout).text(),
+			new Response(jsonProc.stderr).text(),
+		]);
+		await jsonProc.exited;
+		expect(jsonProc.exitCode, stderr).toBe(0);
+		const report = JSON.parse(stdout);
+		expect(report.totalFiles).toBe(1);
+		expect(report.excludedGeneratedFileCount).toBe(2);
+		expect(report.excludedGeneratedFiles).toEqual([
+			path.join(dir, ".next/dev/types/route-metadata.d.ts"),
+			path.join(dir, ".next/types/cache-life.d.ts"),
+		]);
+		expect(report.warnings).toContain(
+			"Excluded 2 framework-generated TypeScript file(s) from analysis."
+		);
+		expect(report.orphanFiles).toEqual([
+			expect.objectContaining({ file: path.join(dir, "types/authored.d.ts") }),
+		]);
+
+		const humanProc = Bun.spawn([...CLI, "unused", dir], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await new Response(humanProc.stdout).text();
+		const humanStderr = await new Response(humanProc.stderr).text();
+		await humanProc.exited;
+		expect(humanProc.exitCode).toBe(0);
+		expect(humanStderr).toContain(
+			"Excluded 2 framework-generated TypeScript file(s) from analysis."
+		);
+
+		await cleanup(dir);
 	});
 
 	test("reports incomplete coverage in JSON and human output", async () => {

--- a/src/commands/unused.ts
+++ b/src/commands/unused.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
 import ts from "typescript";
 import { logger } from "../cli-logger.ts";
+import {
+	createFrameworkGeneratedArtifactClassifier,
+	excludeFrameworkGeneratedArtifacts,
+	generatedArtifactWarning,
+} from "../core/generated-artifacts.ts";
 import { filterGitignored } from "../core/git.ts";
 import type { DependencyGraph } from "../core/graph.ts";
 import {
@@ -95,6 +100,9 @@ export interface OrphanFile {
 
 export interface UnusedReport {
 	schemaVersion: typeof UNUSED_SCHEMA_VERSION;
+	warnings: string[];
+	excludedGeneratedFiles: string[];
+	excludedGeneratedFileCount: number;
 	unused: UnusedExport[];
 	orphanFiles: OrphanFile[];
 	totalExports: number;
@@ -142,6 +150,9 @@ export async function findUnusedExports(
 	if (!tsconfigPath) {
 		return {
 			schemaVersion: UNUSED_SCHEMA_VERSION,
+			warnings: [],
+			excludedGeneratedFiles: [],
+			excludedGeneratedFileCount: 0,
 			unused: [],
 			orphanFiles: [],
 			totalExports: 0,
@@ -189,14 +200,30 @@ export async function findUnusedExportsFromGraphs(
 	options?: { ignore?: string; entrypointGlobs?: string | string[] }
 ): Promise<UnusedReport> {
 	const absoluteDir = path.resolve(directory);
-
+	const frameworkClassifier = await createFrameworkGeneratedArtifactClassifier(
+		graphs.map(({ tsconfigPath }) => tsconfigPath)
+	);
+	const excludedGeneratedFiles = new Set<string>();
+	const filteredGraphs = graphs.map((result) => {
+		const filtered = excludeFrameworkGeneratedArtifacts(
+			result.graph,
+			frameworkClassifier
+		);
+		for (const artifact of filtered.excludedGeneratedFiles) {
+			excludedGeneratedFiles.add(artifact.file);
+		}
+		return { ...result, graph: filtered.graph };
+	});
 	const graph =
-		graphs.length > 1
-			? mergeDependencyGraphs(graphs.map((result) => result.graph))
-			: graphs[0]?.graph;
+		filteredGraphs.length > 1
+			? mergeDependencyGraphs(filteredGraphs.map((result) => result.graph))
+			: filteredGraphs[0]?.graph;
 	if (!graph) {
 		return {
 			schemaVersion: UNUSED_SCHEMA_VERSION,
+			warnings: [],
+			excludedGeneratedFiles: [],
+			excludedGeneratedFileCount: 0,
 			unused: [],
 			orphanFiles: [],
 			totalExports: 0,
@@ -215,9 +242,15 @@ export async function findUnusedExportsFromGraphs(
 	const importedBindings = new Map<string, Set<string>>();
 	const scannedConfigs: string[] = [];
 
-	for (const { tsconfigPath: configPath, graph } of graphs) {
+	for (const {
+		tsconfigPath: configPath,
+		graph: projectGraph,
+	} of filteredGraphs) {
 		scannedConfigs.push(configPath);
-		mergeImportedBindings(importedBindings, buildImportedBindingsMap(graph));
+		mergeImportedBindings(
+			importedBindings,
+			buildImportedBindingsMap(projectGraph)
+		);
 	}
 
 	// Candidate files: those under the target directory, across all configs.
@@ -324,6 +357,12 @@ export async function findUnusedExportsFromGraphs(
 
 	return {
 		schemaVersion: UNUSED_SCHEMA_VERSION,
+		warnings:
+			excludedGeneratedFiles.size > 0
+				? [generatedArtifactWarning(excludedGeneratedFiles.size)]
+				: [],
+		excludedGeneratedFiles: [...excludedGeneratedFiles].sort(),
+		excludedGeneratedFileCount: excludedGeneratedFiles.size,
 		unused,
 		orphanFiles,
 		totalExports,
@@ -869,6 +908,18 @@ export async function unusedCommand(options: UnusedOptions): Promise<void> {
 	logger.info(
 		`📊 Scanned ${report.totalExports} export(s) across ${report.totalFiles} file(s)\n`
 	);
+
+	if (report.excludedGeneratedFileCount > 0) {
+		logger.warn(
+			`⚠️  ${generatedArtifactWarning(report.excludedGeneratedFileCount)}`
+		);
+		if (verbose) {
+			for (const file of report.excludedGeneratedFiles) {
+				logger.warn(`   ${path.relative(absoluteDir, file)}`);
+			}
+		}
+		logger.empty();
+	}
 
 	if (report.coverageIncomplete) {
 		logger.warn(

--- a/src/core/generated-artifacts.test.ts
+++ b/src/core/generated-artifacts.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import path from "node:path";
+import { cleanup, makeFixture } from "../commands/__test-helpers.ts";
+import {
+	createFrameworkGeneratedArtifactClassifier,
+	excludeFrameworkGeneratedArtifacts,
+	generatedArtifactWarning,
+} from "./generated-artifacts.ts";
+import type { DependencyGraph } from "./graph.ts";
+
+const fixtures: string[] = [];
+
+afterAll(async () => {
+	for (const directory of fixtures) {
+		await cleanup(directory);
+	}
+});
+
+describe("framework-generated TypeScript artifacts", () => {
+	test("classifies only Next-generated type trees under the default distDir", async () => {
+		const root = await makeFixture(
+			"generated-default",
+			{ "tsconfig.json": "{}\n" },
+			{ outsideRepo: true }
+		);
+		fixtures.push(root);
+		const tsconfigPath = path.join(root, "tsconfig.json");
+		const classifier = await createFrameworkGeneratedArtifactClassifier([
+			tsconfigPath,
+		]);
+
+		expect(
+			classifier.classify(path.join(root, ".next/types/routes.d.ts"))
+		).toEqual(
+			expect.objectContaining({
+				framework: "next",
+				generatedDirectory: path.join(root, ".next"),
+				tsconfigPath,
+			})
+		);
+		expect(
+			classifier.classify(path.join(root, ".next/dev/types/cache-life.d.ts"))
+		).toBeDefined();
+		expect(classifier.classify(path.join(root, ".next/cache/trace.ts"))).toBe(
+			undefined
+		);
+		expect(classifier.classify(path.join(root, "src/authored.d.ts"))).toBe(
+			undefined
+		);
+	});
+
+	test("reads a static custom distDir without executing Next config code", async () => {
+		const root = await makeFixture(
+			"generated-custom",
+			{
+				"next.config.ts": [
+					"throw new Error('must not execute');",
+					"const config = { distDir: 'build-output' } as const;",
+					"export default config;",
+				].join("\n"),
+				"tsconfig.json": "{}\n",
+			},
+			{ outsideRepo: true }
+		);
+		fixtures.push(root);
+		const tsconfigPath = path.join(root, "tsconfig.json");
+		const classifier = await createFrameworkGeneratedArtifactClassifier([
+			tsconfigPath,
+		]);
+
+		expect(
+			classifier.classify(path.join(root, "build-output/types/routes.d.ts"))
+		).toEqual(
+			expect.objectContaining({
+				generatedDirectory: path.join(root, "build-output"),
+				tsconfigPath,
+			})
+		);
+		expect(
+			classifier.classify(
+				path.join(root, "build-output/dev/types/route-metadata.d.ts")
+			)
+		).toBeDefined();
+	});
+
+	test("removes generated sources and references from a dependency graph", async () => {
+		const root = await makeFixture(
+			"generated-graph",
+			{ "tsconfig.json": "{}\n" },
+			{ outsideRepo: true }
+		);
+		fixtures.push(root);
+		const authored = path.join(root, "src/authored.ts");
+		const generated = path.join(root, ".next/types/routes.d.ts");
+		const graph: DependencyGraph = {
+			imports: new Map([
+				[
+					authored,
+					[
+						{
+							sourceFile: authored,
+							specifier: generated,
+							resolvedPath: generated,
+							type: "import",
+							line: 1,
+							column: 1,
+							isTypeOnly: true,
+						},
+					],
+				],
+				[generated, []],
+			]),
+			importedBy: new Map(),
+			skippedFiles: [generated],
+			barrelFiles: new Set([generated]),
+			barrelReExports: new Map([[generated, [authored]]]),
+		};
+		const classifier = await createFrameworkGeneratedArtifactClassifier([
+			path.join(root, "tsconfig.json"),
+		]);
+
+		const result = excludeFrameworkGeneratedArtifacts(graph, classifier);
+
+		expect(result.excludedGeneratedFiles.map(({ file }) => file)).toEqual([
+			generated,
+		]);
+		expect(result.graph.imports).toEqual(new Map([[authored, []]]));
+		expect(result.graph.importedBy.size).toBe(0);
+		expect(result.graph.skippedFiles).toEqual([]);
+		expect(result.graph.barrelFiles.size).toBe(0);
+		expect(result.graph.barrelReExports.size).toBe(0);
+		expect(generatedArtifactWarning(1)).toBe(
+			"Excluded 1 framework-generated TypeScript file(s) from analysis."
+		);
+	});
+});

--- a/src/core/generated-artifacts.ts
+++ b/src/core/generated-artifacts.ts
@@ -1,0 +1,316 @@
+import path from "node:path";
+import ts from "typescript";
+import type { ModuleReference } from "../types/graph.ts";
+import type { DependencyGraph } from "./graph.ts";
+import { isWithinPath } from "./path-utils.ts";
+import { normalizePath } from "./resolver.ts";
+
+const NEXT_CONFIG_FILENAMES = [
+	"next.config.ts",
+	"next.config.mts",
+	"next.config.cts",
+	"next.config.js",
+	"next.config.mjs",
+	"next.config.cjs",
+] as const;
+
+export interface FrameworkGeneratedArtifact {
+	file: string;
+	framework: "next";
+	generatedDirectory: string;
+	tsconfigPath: string;
+}
+
+export interface FrameworkGeneratedArtifactClassifier {
+	classify(file: string): FrameworkGeneratedArtifact | undefined;
+}
+
+interface NextGeneratedBoundary {
+	generatedDirectory: string;
+	tsconfigPath: string;
+	typeDirectories: string[];
+}
+
+const propertyName = (name: ts.PropertyName): string | undefined => {
+	if (
+		ts.isIdentifier(name) ||
+		ts.isStringLiteral(name) ||
+		ts.isNumericLiteral(name)
+	) {
+		return name.text;
+	}
+	return undefined;
+};
+
+const variableInitializers = (
+	sourceFile: ts.SourceFile
+): Map<string, ts.Expression> => {
+	const initializers = new Map<string, ts.Expression>();
+	for (const statement of sourceFile.statements) {
+		if (!ts.isVariableStatement(statement)) {
+			continue;
+		}
+		for (const declaration of statement.declarationList.declarations) {
+			if (ts.isIdentifier(declaration.name) && declaration.initializer) {
+				initializers.set(declaration.name.text, declaration.initializer);
+			}
+		}
+	}
+	return initializers;
+};
+
+const unwrapConfigObject = (
+	expression: ts.Expression,
+	initializers: Map<string, ts.Expression>,
+	seen = new Set<string>()
+): ts.ObjectLiteralExpression | undefined => {
+	if (ts.isObjectLiteralExpression(expression)) {
+		return expression;
+	}
+	if (
+		ts.isParenthesizedExpression(expression) ||
+		ts.isAsExpression(expression) ||
+		ts.isSatisfiesExpression(expression) ||
+		ts.isTypeAssertionExpression(expression)
+	) {
+		return unwrapConfigObject(expression.expression, initializers, seen);
+	}
+	if (ts.isCallExpression(expression)) {
+		const firstArgument = expression.arguments[0];
+		return firstArgument
+			? unwrapConfigObject(firstArgument, initializers, seen)
+			: undefined;
+	}
+	if (!ts.isIdentifier(expression) || seen.has(expression.text)) {
+		return undefined;
+	}
+	const initializer = initializers.get(expression.text);
+	if (!initializer) {
+		return undefined;
+	}
+	seen.add(expression.text);
+	return unwrapConfigObject(initializer, initializers, seen);
+};
+
+const isModuleExports = (expression: ts.Expression): boolean =>
+	ts.isPropertyAccessExpression(expression) &&
+	ts.isIdentifier(expression.expression) &&
+	expression.expression.text === "module" &&
+	expression.name.text === "exports";
+
+const exportedConfigObject = (
+	sourceFile: ts.SourceFile
+): ts.ObjectLiteralExpression | undefined => {
+	const initializers = variableInitializers(sourceFile);
+	for (const statement of sourceFile.statements) {
+		if (ts.isExportAssignment(statement)) {
+			const config = unwrapConfigObject(statement.expression, initializers);
+			if (config) {
+				return config;
+			}
+		}
+		if (
+			ts.isExpressionStatement(statement) &&
+			ts.isBinaryExpression(statement.expression) &&
+			statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			isModuleExports(statement.expression.left)
+		) {
+			const config = unwrapConfigObject(
+				statement.expression.right,
+				initializers
+			);
+			if (config) {
+				return config;
+			}
+		}
+	}
+	return undefined;
+};
+
+const staticDistDir = (
+	sourceText: string,
+	configPath: string
+): string | null => {
+	const sourceFile = ts.createSourceFile(
+		configPath,
+		sourceText,
+		ts.ScriptTarget.Latest,
+		true
+	);
+	const config = exportedConfigObject(sourceFile);
+	if (!config) {
+		return null;
+	}
+	const property = config.properties.find(
+		(candidate): candidate is ts.PropertyAssignment =>
+			ts.isPropertyAssignment(candidate) &&
+			propertyName(candidate.name) === "distDir"
+	);
+	if (!property) {
+		return null;
+	}
+	const initializer = property.initializer;
+	return ts.isStringLiteral(initializer) ||
+		ts.isNoSubstitutionTemplateLiteral(initializer)
+		? initializer.text
+		: null;
+};
+
+const configuredNextDistDir = async (
+	projectRoot: string
+): Promise<string | null> => {
+	for (const filename of NEXT_CONFIG_FILENAMES) {
+		const configPath = path.join(projectRoot, filename);
+		const configFile = Bun.file(configPath);
+		if (!(await configFile.exists())) {
+			continue;
+		}
+		try {
+			return staticDistDir(await configFile.text(), configPath);
+		} catch {
+			return null;
+		}
+	}
+	return null;
+};
+
+const nextBoundary = (
+	generatedDirectory: string,
+	tsconfigPath: string
+): NextGeneratedBoundary => ({
+	generatedDirectory: normalizePath(generatedDirectory),
+	tsconfigPath: normalizePath(tsconfigPath),
+	typeDirectories: [
+		normalizePath(path.join(generatedDirectory, "types")),
+		normalizePath(path.join(generatedDirectory, "dev", "types")),
+	],
+});
+
+/**
+ * Build a non-executing classifier for framework-owned TypeScript artifacts.
+ *
+ * Next's default `.next` directory is always recognized. A custom `distDir`
+ * is read only when it is a static string in the exported config object; the
+ * config module is parsed as TypeScript and never imported or executed.
+ */
+export async function createFrameworkGeneratedArtifactClassifier(
+	tsconfigPaths: readonly string[]
+): Promise<FrameworkGeneratedArtifactClassifier> {
+	const boundaries: NextGeneratedBoundary[] = [];
+	const seen = new Set<string>();
+	for (const inputConfigPath of tsconfigPaths) {
+		const tsconfigPath = normalizePath(path.resolve(inputConfigPath));
+		if (seen.has(tsconfigPath)) {
+			continue;
+		}
+		seen.add(tsconfigPath);
+		const projectRoot = path.dirname(tsconfigPath);
+		boundaries.push(
+			nextBoundary(path.join(projectRoot, ".next"), tsconfigPath)
+		);
+
+		const configured = await configuredNextDistDir(projectRoot);
+		if (!configured) {
+			continue;
+		}
+		const generatedDirectory = normalizePath(
+			path.resolve(projectRoot, configured)
+		);
+		if (
+			isWithinPath(projectRoot, generatedDirectory) &&
+			generatedDirectory !== normalizePath(path.join(projectRoot, ".next"))
+		) {
+			boundaries.push(nextBoundary(generatedDirectory, tsconfigPath));
+		}
+	}
+
+	boundaries.sort(
+		(a, b) => b.generatedDirectory.length - a.generatedDirectory.length
+	);
+	return {
+		classify(file: string): FrameworkGeneratedArtifact | undefined {
+			const normalizedFile = normalizePath(path.resolve(file));
+			const boundary = boundaries.find((candidate) =>
+				candidate.typeDirectories.some((directory) =>
+					isWithinPath(directory, normalizedFile)
+				)
+			);
+			return boundary
+				? {
+						file: normalizedFile,
+						framework: "next",
+						generatedDirectory: boundary.generatedDirectory,
+						tsconfigPath: boundary.tsconfigPath,
+					}
+				: undefined;
+		},
+	};
+}
+
+export function generatedArtifactWarning(count: number): string {
+	return `Excluded ${count} framework-generated TypeScript file(s) from analysis.`;
+}
+
+/** Remove framework-generated nodes from both sides of a dependency graph. */
+export function excludeFrameworkGeneratedArtifacts(
+	graph: DependencyGraph,
+	classifier: FrameworkGeneratedArtifactClassifier
+): {
+	graph: DependencyGraph;
+	excludedGeneratedFiles: FrameworkGeneratedArtifact[];
+} {
+	const excludedByFile = new Map<string, FrameworkGeneratedArtifact>();
+	const classify = (file: string): FrameworkGeneratedArtifact | undefined => {
+		const artifact = classifier.classify(file);
+		if (artifact) {
+			excludedByFile.set(artifact.file, artifact);
+		}
+		return artifact;
+	};
+	const imports = new Map<string, ModuleReference[]>();
+	const importedBy = new Map<string, ModuleReference[]>();
+
+	for (const [file, refs] of graph.imports) {
+		if (classify(file)) {
+			continue;
+		}
+		const retained = refs.filter((ref) => !classify(ref.resolvedPath));
+		imports.set(file, retained);
+		for (const ref of retained) {
+			const target = normalizePath(ref.resolvedPath);
+			const existing = importedBy.get(target) ?? [];
+			existing.push(ref);
+			importedBy.set(target, existing);
+		}
+	}
+	for (const file of graph.importedBy.keys()) {
+		classify(file);
+	}
+
+	const barrelReExports = new Map<string, string[]>();
+	for (const [file, reExports] of graph.barrelReExports) {
+		if (classify(file)) {
+			continue;
+		}
+		barrelReExports.set(
+			file,
+			reExports.filter((target) => !classify(target))
+		);
+	}
+
+	return {
+		graph: {
+			...graph,
+			imports,
+			importedBy,
+			skippedFiles: graph.skippedFiles.filter((file) => !classify(file)),
+			barrelFiles: new Set(
+				[...graph.barrelFiles].filter((file) => !classify(file))
+			),
+			barrelReExports,
+		},
+		excludedGeneratedFiles: [...excludedByFile.values()].sort((a, b) =>
+			a.file.localeCompare(b.file)
+		),
+	};
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -90,6 +90,7 @@ import {
 } from "./commands/tidy.ts";
 import { executeUndo } from "./commands/undo.ts";
 import { findUnusedExports } from "./commands/unused.ts";
+import { createFrameworkGeneratedArtifactClassifier } from "./core/generated-artifacts.ts";
 import { isWorktreeDirty } from "./core/git.ts";
 import { buildDependencyGraph } from "./core/graph.ts";
 import {
@@ -418,14 +419,20 @@ async function auditTool(
 	}
 	const projectConfig = loadProject(tsconfigPath);
 	const graph = await buildDependencyGraph(projectConfig);
+	const frameworkClassifier = await createFrameworkGeneratedArtifactClassifier([
+		tsconfigPath,
+	]);
 	const thresholds = {
 		fanOutThreshold: options.fanOutThreshold ?? 10,
 		fanInThreshold: options.fanInThreshold ?? 10,
 		exportThreshold: options.exportThreshold ?? 8,
 	};
-	const report = buildAuditReport(graph, thresholds, [
-		{ graph, project: projectConfig },
-	]);
+	const report = buildAuditReport(
+		graph,
+		thresholds,
+		[{ graph, project: projectConfig }],
+		frameworkClassifier
+	);
 	return jsonText({
 		...auditReportToJson(report, absoluteDir),
 		thresholds,
@@ -488,6 +495,11 @@ async function unusedTool(
 			path.relative(absoluteDir, file)
 		),
 		coverageIncomplete: report.coverageIncomplete,
+		warnings: report.warnings,
+		excludedGeneratedFileCount: report.excludedGeneratedFileCount,
+		excludedGeneratedFiles: report.excludedGeneratedFiles.map((file) =>
+			path.relative(absoluteDir, file)
+		),
 		orphanFiles: report.orphanFiles.map((orphan) => ({
 			file: path.relative(absoluteDir, orphan.file),
 			exportNames: orphan.exportNames,

--- a/src/types/naming.ts
+++ b/src/types/naming.ts
@@ -54,11 +54,13 @@ export interface NamingReport {
 	directory: string;
 	generatedAt: string;
 	warnings: string[];
+	excludedGeneratedFiles: string[];
 	findings: NamingViolation[];
 	summary: {
 		totalFindings: number;
 		filesTouched: number;
 		totalFiles: number;
+		excludedGeneratedFileCount: number;
 		totalDirectories: number;
 		minSiblings: number;
 		majorityThreshold: number;


### PR DESCRIPTION
## Summary

- exclude Next-generated declarations under `.next/types/**` and `.next/dev/types/**` from audit, naming, and unused analysis
- discover static custom `distDir` values by parsing Next config without executing project code
- report excluded counts, paths, and a shared warning consistently in human, JSON, MCP, and library-facing results
- preserve authored declaration analysis and existing compiler `outDir` audit behavior
- register the source-backed behavior as `ANLY-001` and `ANLY-002` in the canonical requirements contract

## What changed

- added a shared dependency-graph classifier/filter for framework-generated artifacts
- integrated that filter before findings are computed across all three read-only analysis commands
- added default `.next`, custom `distDir`, graph-reference, authored declaration, and report-surface regressions
- regenerated the independent structure, document-quality, and implementation receipts against implementation commit `7016141`

## Why

Next-generated declaration files were being counted as authored source, producing misleading audit metrics, naming findings, unused exports, and orphan-file results. A shared classifier keeps those commands aligned while retaining genuine `.d.ts` files outside framework output.

## Scope

This PR implements automatic Next output discovery required by #190. A new user-configurable generated-directory glob option is intentionally not added because it would introduce a separate cross-command CLI, MCP, library, and configuration contract beyond the accepted criteria.

## Testing

- focused: 115 tests passed, 0 failed, 390 assertions across 6 files
- full suite: 933 tests passed, 0 failed, 2594 assertions across 69 files
- guarded implementation commit: 702 affected tests passed, 0 failed, 2214 assertions across 55 files
- `pnpm run check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build:lib`
- `pnpm run verify:size` (0.39 MB / 5 MB)
- strict declaration similarity scan at `0.95`
- canonical requirements validator: 38 scenarios, 0 structural errors

## Risk / rollout

Low-to-moderate analysis-scope risk. The filter removes only the `types` and `dev/types` trees under default or statically configured Next output directories. Next config is parsed and never executed; dynamic `distDir` expressions safely retain default `.next` recognition instead of guessing.

## Screenshots / evidence

Not applicable; this is CLI, MCP, and library analysis behavior covered by automated output assertions.

Closes #190
