### PR TITLE
fix(barrel): exclude framework metadata entrypoints

### DIFF
--- a/.requirements-status.json
+++ b/.requirements-status.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "projectId": "mherod/resect",
   "requirementsFile": "REQUIREMENTS.md",
-  "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
-  "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
-  "generatedAt": "2026-08-08T04:17:43Z",
+  "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
+  "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
+  "generatedAt": "2026-08-08T04:49:24Z",
   "validator": {
     "name": "generate-requirements",
     "version": "2.0.0",
@@ -13,15 +13,15 @@
   "validation": {
     "structure": {
       "status": "PASS",
-      "receiptId": "STRUCT-20260808-001",
+      "receiptId": "STRUCT-20260808-002",
       "validator": "validate-bdd",
       "validatorVersion": "2.0.0",
       "command": "bun $HOME/.agents/skills/generate-requirements/scripts/validate-bdd.js REQUIREMENTS.md --status-log .requirements-status.json",
-      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
-      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
-      "generatedAt": "2026-08-08T04:17:43Z",
+      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
+      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
+      "generatedAt": "2026-08-08T04:49:24Z",
       "counts": {
-        "checked": 38,
+        "checked": 40,
         "errors": 0,
         "warnings": 0
       },
@@ -31,41 +31,42 @@
     },
     "documentQuality": {
       "status": "PASS",
-      "receiptId": "QUALITY-20260808-001",
+      "receiptId": "QUALITY-20260808-002",
       "validator": "generate-requirements-manual-review",
       "validatorVersion": "2.0.0",
       "command": "generate-requirements 2.0 manual review of REQUIREMENTS.md",
-      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
-      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
-      "generatedAt": "2026-08-08T04:17:43Z",
+      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
+      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
+      "generatedAt": "2026-08-08T04:49:24Z",
       "counts": {
-        "checked": 38,
+        "checked": 40,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "Reviewed all 38 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
-        "Framework-generated exclusions are explicit across the shared analysis actor group, default and configured Next output boundaries, human and machine-readable results, and authored declaration preservation; no preamble or priority-skew warning was computed."
+        "Reviewed all 40 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
+        "Framework-aware barrel analysis is explicit across the shared analysis actor group, valid App Router locations, same-basename controls, structural inventory, unused findings, and CLI, MCP, and library surfaces; no preamble or priority-skew warning was computed."
       ]
     },
     "implementation": {
       "status": "PASS",
-      "receiptId": "IMPL-20260808-001",
+      "receiptId": "IMPL-20260808-002",
       "validator": "bun-test-plus-clause-audit",
       "validatorVersion": "1.3.14+generate-requirements-2.0.0",
-      "command": "bun test src/core/generated-artifacts.test.ts src/commands/audit.test.ts src/commands/naming.test.ts src/commands/unused.test.ts src/mcp-schema-parity.test.ts src/index.test.ts --timeout=20000 --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
-      "requirementsSha256": "9ff9714fcd91145e28fa241edb60e8155ee8a022b01bb2d5c7c230c69f542cad",
-      "sourceCommit": "7016141450ba0d916a00c088e76e6955422d10b7",
-      "generatedAt": "2026-08-08T04:17:43Z",
+      "command": "bun test src/commands/barrel.test.ts src/commands/command-spec.test.ts src/mcp-schema-parity.test.ts src/index.test.ts --timeout=20000 --parallel=4 && bun test --timeout=20000 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
+      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
+      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
+      "generatedAt": "2026-08-08T04:49:24Z",
       "counts": {
-        "checked": 38,
+        "checked": 40,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "The generated-artifact, audit, naming, unused, MCP parity, and library focus passed 115 tests with 0 failures and 390 assertions across 6 files.",
-        "The complete Bun suite passed 933 tests with 0 failures and 2594 assertions across 69 files; the guarded commit additionally passed 702 affected tests with 0 failures and 2214 assertions across 55 files.",
-        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed against source commit 7016141.",
+        "The barrel, command-specification, MCP parity, and library focus passed 62 tests with 0 failures and 397 assertions across 4 files.",
+        "The repository-guide canonical complete Bun suite passed 936 tests with 0 failures and 2605 assertions across 69 files; the guarded commit additionally passed 65 affected tests with 0 failures and 404 assertions across 5 files.",
+        "Exploratory full-suite runs with forced four-way parallelism produced rotating unrelated 20-second timeouts; each sampled timeout passed in isolation before the canonical sequential full suite passed.",
+        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed against source commit 02a09a3.",
         "MOVE-001 through MOVE-003 map to src/commands/move.test.ts and src/commands/move.ts at source commit 52106e7.",
         "TIDY-001, TIDY-002, and ROLL-001 map to src/commands/tidy.test.ts, src/core/rollback.test.ts, src/commands/tidy.ts, and src/core/rollback.ts at source commit 52106e7.",
         "CFG-001 through CFG-006 map to src/core/project-config.test.ts, src/commands/config-defaults.test.ts, src/commands/discover.test.ts, and their corresponding implementation files at source commit 52106e7.",
@@ -77,32 +78,33 @@
         "NAM-001 through NAM-003 map to src/commands/naming.test.ts, src/commands/naming.ts, src/commands/registry.ts, src/mcp-server.ts, src/types/naming.ts, and src/index.test.ts; 50 focused tests passed with 0 failures and 154 assertions.",
         "JOUR-001 and JOUR-002 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/journal-integration.test.ts, the move, rename, alias, tidy, MCP, registry, and library surfaces.",
         "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts.",
-        "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit 7016141."
+        "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit 7016141.",
+        "BARL-001 and BARL-002 map to src/core/framework-conventions.ts, src/commands/barrel.ts, src/commands/barrel.test.ts, src/mcp-server.ts, and src/index.test.ts at source commit 02a09a3."
       ]
     }
   },
   "metrics": {
-    "totalScenarios": 38,
+    "totalScenarios": 40,
     "byDelivery": {
-      "V1": 38,
+      "V1": 40,
       "V2": 0,
       "LATER": 0,
       "UNSLICED": 0
     },
     "byDecision": {
-      "DECIDED": 38,
+      "DECIDED": 40,
       "OPEN": 0
     },
     "byPriority": {
       "P0": 4,
-      "P1": 22,
+      "P1": 24,
       "P2": 12,
       "P3": 0
     },
     "priorityByDelivery": {
       "V1": {
         "P0": 4,
-        "P1": 22,
+        "P1": 24,
         "P2": 12,
         "P3": 0
       },
@@ -126,15 +128,15 @@
       }
     },
     "byFidelity": {
-      "VERIFIED": 38,
+      "VERIFIED": 40,
       "DRIFTED": 0,
       "MISSING": 0,
       "UNTESTABLE": 0
     },
     "coverage": {
       "v1Decided": {
-        "eligible": 38,
-        "verified": 38,
+        "eligible": 40,
+        "verified": 40,
         "percentage": 100
       },
       "v1LaunchCritical": {
@@ -176,8 +178,8 @@
     "fidelityNoteMismatchIds": [],
     "orphanAnchorIds": [],
     "preamble": {
-      "linesBeforeFirstScenario": 104,
-      "percentageBeforeFirstScenario": 22.6,
+      "linesBeforeFirstScenario": 105,
+      "percentageBeforeFirstScenario": 21.9,
       "warning": false,
       "disposition": null
     },

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -9,7 +9,7 @@
 
 ## Product Ground Truth
 
-Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, and source-focused read-only analysis. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
+Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, source-focused read-only analysis, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
 
 ## Source Register
 
@@ -27,12 +27,13 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | SRC-010 | Repository owner issue | 2026-07-11 | https://github.com/mherod/resect/issues/162 | Explicit filename-casing audit, surface parity, warning, and fix behavior |
 | SRC-011 | Repository owner issue | 2026-08-05 re-grounding | https://github.com/mherod/resect/issues/134 | Opt-in operation journal, guarded user-initiated undo, retention cap, and public-surface parity |
 | SRC-012 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/190 | Framework-generated TypeScript exclusion across audit, naming, and unused analysis |
+| SRC-013 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/189 | Framework metadata entrypoint treatment in barrel inventory and unused findings |
 
 ## Delivery and Decision Register
 
 | Decision ID | Decision | State | Delivery | Sources | Reversal condition |
 |---|---|---|---|---|---|
-| DR-001 | This baseline covers the eleven accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012 | A repository-owner decision expands or retires the baseline. |
+| DR-001 | This baseline covers the twelve accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013 | A repository-owner decision expands or retires the baseline. |
 | DR-002 | Resect is a local developer tool without accounts, tenants, sessions, notifications, analytics, or media. | DECIDED | V1 | SRC-007 | A published contract adds one of these product surfaces. |
 | DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009 | The execution model moves into a managed remote sandbox. |
 | DR-004 | Batch moves are sequential within one process and use one setup, worktree guard, and verification boundary. | DECIDED | V1 | SRC-006 | A repository-owner decision introduces parallel or cross-process coordination. |
@@ -43,8 +44,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Actor | Access scope and capabilities | Limitation and direct-attempt coverage | Passive perspective |
 |---|---|---|---|
-| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, and unsafe undo attempts are refused or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004. | Resolved configuration, previews, journal identifiers, target-casing findings, source-focused metrics, and generated-artifact exclusions are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002. |
-| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, target-casing findings, audit exclusions, and generated-artifact exclusions are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, AUDIT-004, ANLY-001, ANLY-002. |
+| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, and unsafe undo attempts are refused or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004. | Resolved configuration, previews, journal identifiers, target-casing findings, source-focused metrics, generated-artifact exclusions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, BARL-001, BARL-002. |
+| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, target-casing findings, audit exclusions, generated-artifact exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002. |
 
 ## Actor Groups
 
@@ -52,7 +53,7 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 |---|---|---|
 | Transform Config Consumer | Operator; API Consumer | Callers that do not request a transform config |
 | Naming Consumer | Operator; API Consumer | Callers that do not invoke the naming surface |
-| Analysis Consumer | Operator; API Consumer | Callers that do not invoke audit, naming, or unused analysis |
+| Analysis Consumer | Operator; API Consumer | Callers that do not invoke audit, naming, unused, or barrel analysis |
 | Refactor Consumer | Operator; API Consumer | Callers that do not invoke the CLI, MCP, or library refactoring surfaces |
 
 ## V1 Launch Critical Path
@@ -66,8 +67,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Coverage row | Scenario IDs or N/A | Decision or rationale |
 |---|---|---|
-| Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001 | Journal, configuration, transform, batch, and target-casing entry points are explicit. |
-| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
+| Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001, BARL-001 | Journal, configuration, transform, batch, target-casing, and barrel-analysis entry points are explicit. |
+| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
 | Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002 | Successful mutations and reversals report the applied operation. |
 | Cancel or alternative exit | UNDO-003, BATCH-001 | Dry-run is the non-mutating alternative. |
 | Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007 | Failure paths preserve truthful outcomes. |
@@ -90,14 +91,14 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Security, session expiry or revocation, and abuse | APPLIES | TRNS-003 | Transform configs execute with host process privileges, so the consumer is warned before execution; SRC-009, DR-003. |
 | Audit and accountability | APPLIES | JOUR-001 | An opt-in local operation history identifies the command, inputs, timestamp, and affected files; SRC-011, DR-006. |
 | Notifications and communication preferences | N/A | — | No notification channel or preference model; DR-002; XC-NA-005. |
-| Search and discovery | APPLIES | CFG-001, CFG-005, AUDIT-001, ANLY-001 | Project configuration and configured source, output, or framework-generated boundaries are discovered and applied. |
+| Search and discovery | APPLIES | CFG-001, CFG-005, AUDIT-001, ANLY-001, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
 | Empty and first-run states | APPLIES | UNDO-005, CFG-006, BATCH-005, BATCH-007 | Missing undo history and config are handled explicitly, and empty batches are rejected. |
 | Limits, quotas, and upgrade or denial behavior | APPLIES | JOUR-002 | Local operation history has a fixed retention limit without a plan or upgrade model; DR-006. |
 | Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004 | Mutating and reversal failures report truthfully and preserve later work unless explicitly forced. |
 | Persistence, interruption, and re-entry | APPLIES | JOUR-001, UNDO-001, UNDO-002, TIDY-002, ROLL-001 | Journal entries persist across command invocations and support a later guarded reversal. |
 | Data lifecycle, retention, deletion, and export | APPLIES | JOUR-002 | Operation history retains only the newest 20 entries; SRC-011, DR-006. |
 | Analytics and telemetry | N/A | — | No analytics or telemetry surface in baseline; DR-002; XC-NA-008. |
-| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001 | Config and graph state are refreshed at their documented boundaries, and read-only analysis represents authored sources rather than framework-generated artifacts. |
+| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, BARL-001, BARL-002 | Config and graph state are refreshed at their documented boundaries, and read-only analysis distinguishes authored structure from framework-consumed entrypoints and generated artifacts. |
 | Media alternatives, captions, transcripts, and reduced motion | N/A | — | No media or motion surface; DR-002; XC-NA-009. |
 
 ## Feature: Safe Refactor Mutation and Rollback
@@ -448,12 +449,31 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 **And** a warning explains that framework-generated TypeScript was excluded
 **And** a machine-readable result identifies the excluded paths
 
+## Feature: Framework-Aware Barrel Analysis
+
+### BARL-001 — Analysis Consumer — Scope unused findings around framework metadata entrypoints
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-013
+
+**Given** a zero-consumer re-export barrel uses a recognized framework metadata filename in a valid App Router tree and an ordinary zero-consumer barrel uses the same basename elsewhere
+**When** an Analysis Consumer runs barrel analysis through a supported CLI, MCP, or library surface
+**Then** the framework metadata entrypoint is absent from unused-barrel findings
+**And** the ordinary barrel remains in unused-barrel findings
+
+### BARL-002 — Analysis Consumer — Preserve framework metadata barrels in structural inventory
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-013
+
+**Given** a re-export barrel uses a recognized framework metadata filename in a valid App Router tree
+**When** an Analysis Consumer runs barrel analysis through a supported CLI, MCP, or library surface
+**Then** the framework metadata entrypoint remains in the general barrel inventory
+
 ## Validation Receipts
 
 | Layer | Status | Receipt | Current artifact |
 |---|---|---|---|
-| Structure | PASS | STRUCT-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
-| Document quality | PASS | QUALITY-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
-| Implementation | PASS | IMPL-20260808-001 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
+| Structure | PASS | STRUCT-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
+| Document quality | PASS | QUALITY-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
+| Implementation | PASS | IMPL-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
 
 The canonical validator, manual product-contract review, and focused implementation audit are independent. Counts, hashes, source commit, commands, timestamps, warning dispositions, and evidence summaries live only in the derived status artifact.

--- a/src/commands/barrel.test.ts
+++ b/src/commands/barrel.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 import type { BarrelScan } from "../types/barrel.ts";
-import { CLI, cleanup, makeFixture } from "./__test-helpers.ts";
+import { CLI, captureOutput, cleanup, makeFixture } from "./__test-helpers.ts";
 import {
 	type BarrelReportContext,
+	barrelCommand,
 	barrelReportToJson,
 	buildBarrelReport,
 } from "./barrel.ts";
@@ -114,6 +116,40 @@ describe("buildBarrelReport", () => {
 		]);
 	});
 
+	// @BDD: BARL-001-Verified
+	// @BDD: BARL-002-Verified
+	test("keeps framework metadata barrels observable without marking them unused", () => {
+		const frameworkBarrels = [
+			"/repo/app/twitter-image.tsx",
+			"/repo/app/blog/opengraph-image.tsx",
+			"/repo/src/app/sitemap.ts",
+		];
+		const ordinaryBarrels = [
+			"/repo/lib/twitter-image.tsx",
+			"/repo/packages/app/lib/twitter-image.tsx",
+		];
+		const scans: BarrelScan[] = [...frameworkBarrels, ...ordinaryBarrels].map(
+			(barrel) => ({
+				barrel,
+				entries: [{ type: "named", name: "value", from: "./source" }],
+				reExportedFiles: [path.join(path.dirname(barrel), "source.ts")],
+			})
+		);
+
+		const report = buildBarrelReport(
+			scans,
+			makeContext({ consumersOf: () => 0 })
+		);
+
+		expect(report.barrels.map(({ barrel }) => barrel)).toEqual([
+			...frameworkBarrels,
+			...ordinaryBarrels,
+		]);
+		expect(report.unusedBarrels.map(({ barrel }) => barrel)).toEqual(
+			ordinaryBarrels
+		);
+	});
+
 	test("reports sub-path export shadowing (#93) and dedupes per barrel+file", () => {
 		const scans: BarrelScan[] = [
 			{
@@ -193,6 +229,78 @@ describe("buildBarrelReport", () => {
 });
 
 describe("barrel command coverage", () => {
+	// @BDD: BARL-001-Verified
+	// @BDD: BARL-002-Verified
+	test("filters framework metadata barrels consistently in JSON and human output", async () => {
+		const dir = await makeFixture(
+			"barrel-framework-entrypoints",
+			{
+				"tsconfig.json": JSON.stringify({
+					compilerOptions: { jsx: "preserve", strict: true },
+					include: ["app/**/*", "lib/**/*"],
+				}),
+				"app/metadata-source.ts": [
+					'export const alt = "Example";',
+					"export const size = { width: 1200, height: 630 };",
+					'export const contentType = "image/png";',
+					"export default function Image() { return null; }",
+				].join("\n"),
+				"app/twitter-image.tsx":
+					'export { alt, contentType, default, size } from "./metadata-source";\n',
+				"app/blog/metadata-source.ts": "export const image = 1;\n",
+				"app/blog/opengraph-image.tsx":
+					'export { image } from "./metadata-source";\n',
+				"app/sitemap-source.ts": "export const sitemap = 1;\n",
+				"app/sitemap.ts": 'export { sitemap } from "./sitemap-source";\n',
+				"lib/metadata-source.ts": "export const ordinary = 1;\n",
+				"lib/twitter-image.tsx":
+					'export { ordinary } from "./metadata-source";\n',
+			},
+			{ outsideRepo: true }
+		);
+
+		try {
+			const jsonResult = await captureOutput(async () => {
+				await barrelCommand({ directory: dir, json: true });
+			});
+			const report = JSON.parse(jsonResult.stdout);
+			expect(
+				report.barrels.map(({ barrel }: { barrel: string }) => barrel)
+			).toEqual(
+				expect.arrayContaining([
+					"app/twitter-image.tsx",
+					"app/blog/opengraph-image.tsx",
+					"app/sitemap.ts",
+					"lib/twitter-image.tsx",
+				])
+			);
+			expect(
+				report.unusedBarrels.map(({ barrel }: { barrel: string }) => barrel)
+			).toEqual(["lib/twitter-image.tsx"]);
+
+			const humanResult = await captureOutput(async () => {
+				await barrelCommand({ directory: dir });
+			});
+			expect(humanResult.stdout).toContain("Unused barrels (1, no importers)");
+			expect(humanResult.stdout).toContain("lib/twitter-image.tsx");
+			expect(humanResult.stdout).not.toContain("app/twitter-image.tsx");
+			expect(humanResult.stdout).not.toContain("app/blog/opengraph-image.tsx");
+			expect(humanResult.stdout).not.toContain("app/sitemap.ts");
+		} finally {
+			await cleanup(dir);
+		}
+	});
+
+	test("MCP barrel analysis serializes the shared report", async () => {
+		const serverSource = await Bun.file(
+			path.resolve(import.meta.dir, "../mcp-server.ts")
+		).text();
+		expect(serverSource).toContain(
+			"const { report, baseDir } = await analyzeBarrels({"
+		);
+		expect(serverSource).toContain("barrelReportToJson(report, baseDir)");
+	});
+
 	test("surfaces skipped files in JSON and human output", async () => {
 		const dir = await makeFixture("barrel-skipped-file", {
 			"tsconfig.json": JSON.stringify({

--- a/src/commands/barrel.ts
+++ b/src/commands/barrel.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { logger } from "../cli-logger.ts";
+import { isFrameworkConventionFile } from "../core/framework-conventions.ts";
 import { type DependencyGraph, withGraphSourceFile } from "../core/graph.ts";
 import { loadProject } from "../core/project.ts";
 import { findSubpathExportForFile, normalizePath } from "../core/resolver.ts";
@@ -105,7 +106,10 @@ export function buildBarrelReport(
 		barrels,
 		wildcardBarrels: barrels.filter((b) => b.wildcardCount > 0),
 		chainedBarrels: barrels.filter((b) => b.reExportsBarrels.length > 0),
-		unusedBarrels: barrels.filter((b) => b.consumers === 0),
+		unusedBarrels: barrels.filter(
+			(barrel) =>
+				barrel.consumers === 0 && !isFrameworkConventionFile(barrel.barrel)
+		),
 		subpathShadowing,
 	};
 }


### PR DESCRIPTION
## Summary

- reuse the shared framework-convention classifier when deriving unused barrel findings
- keep framework metadata entrypoints in the general barrel inventory while ordinary same-named barrels remain eligible for unused findings
- add regression coverage for library, human, JSON, and MCP paths
- register BARL-001 and BARL-002 with source-bound requirements receipts

## Why

Next.js consumes metadata entrypoints such as app/twitter-image.tsx by filename, so a zero-import count is not evidence that the route is unused. The barrel report should suppress only that incorrect verdict in valid App Router locations without hiding the file structure or exempting ordinary files elsewhere.

## Testing

- bun test src/commands/barrel.test.ts src/commands/command-spec.test.ts src/mcp-schema-parity.test.ts src/index.test.ts --timeout=20000 --parallel=4 (62 pass)
- bun test --timeout=20000 (936 pass, 0 fail, 2,605 assertions)
- pnpm run check
- pnpm run lint
- pnpm run typecheck
- pnpm run build:lib
- pnpm run verify:size
- guarded commit hooks: affected and full suites, similarity scan, compiled CLI/MCP builds, global checkout registration, and formatting all passed

Forced four-way exploratory full-suite runs showed rotating unrelated 20-second timeouts; each sampled timeout passed in isolation, and both the canonical sequential suite and the guarded full-suite hook passed all 936 tests.

## Risk / Rollout

Low risk. This changes only the unusedBarrels projection of the read-only barrel report. The complete barrels inventory is unchanged, and same-basename controls outside recognized framework locations remain reportable.

## Evidence

- Requirements: BARL-001, BARL-002
- Receipts: STRUCT-20260808-002, QUALITY-20260808-002, IMPL-20260808-002

Closes #189
