### PR TITLE
fix(naming): complete framework conventions

### DIFF
--- a/.requirements-status.json
+++ b/.requirements-status.json
@@ -2,26 +2,26 @@
   "schemaVersion": 2,
   "projectId": "mherod/resect",
   "requirementsFile": "REQUIREMENTS.md",
-  "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
-  "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
-  "generatedAt": "2026-08-08T04:49:24Z",
+  "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
+  "sourceCommit": "0f748f3a0b2d092e39d7902e295106ad3447194c",
+  "generatedAt": "2026-08-08T05:19:41Z",
   "validator": {
     "name": "generate-requirements",
     "version": "2.0.0",
-    "command": "bun $HOME/.agents/skills/generate-requirements/scripts/validate-bdd.js REQUIREMENTS.md --status-log .requirements-status.json"
+    "command": "bun scripts/validate-bdd.js /Users/matthew.herod/Development/resect/REQUIREMENTS.md --status-log /Users/matthew.herod/Development/resect/.requirements-status.json"
   },
   "validation": {
     "structure": {
       "status": "PASS",
-      "receiptId": "STRUCT-20260808-002",
+      "receiptId": "STRUCT-20260808-003",
       "validator": "validate-bdd",
       "validatorVersion": "2.0.0",
-      "command": "bun $HOME/.agents/skills/generate-requirements/scripts/validate-bdd.js REQUIREMENTS.md --status-log .requirements-status.json",
-      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
-      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
-      "generatedAt": "2026-08-08T04:49:24Z",
+      "command": "bun scripts/validate-bdd.js /Users/matthew.herod/Development/resect/REQUIREMENTS.md --status-log /Users/matthew.herod/Development/resect/.requirements-status.json",
+      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
+      "sourceCommit": "0f748f3a0b2d092e39d7902e295106ad3447194c",
+      "generatedAt": "2026-08-08T05:19:41Z",
       "counts": {
-        "checked": 40,
+        "checked": 42,
         "errors": 0,
         "warnings": 0
       },
@@ -31,42 +31,41 @@
     },
     "documentQuality": {
       "status": "PASS",
-      "receiptId": "QUALITY-20260808-002",
+      "receiptId": "QUALITY-20260808-003",
       "validator": "generate-requirements-manual-review",
       "validatorVersion": "2.0.0",
       "command": "generate-requirements 2.0 manual review of REQUIREMENTS.md",
-      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
-      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
-      "generatedAt": "2026-08-08T04:49:24Z",
+      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
+      "sourceCommit": "0f748f3a0b2d092e39d7902e295106ad3447194c",
+      "generatedAt": "2026-08-08T05:19:41Z",
       "counts": {
-        "checked": 40,
+        "checked": 42,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "Reviewed all 40 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
-        "Framework-aware barrel analysis is explicit across the shared analysis actor group, valid App Router locations, same-basename controls, structural inventory, unused findings, and CLI, MCP, and library surfaces; no preamble or priority-skew warning was computed."
+        "Reviewed all 42 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
+        "Framework-aware naming safety is explicit across human-readable and structured findings, valid App Router locations, ordinary and invalid-location controls, no-op suppression, and apply planning; no preamble or priority-skew warning was computed."
       ]
     },
     "implementation": {
       "status": "PASS",
-      "receiptId": "IMPL-20260808-002",
+      "receiptId": "IMPL-20260808-003",
       "validator": "bun-test-plus-clause-audit",
       "validatorVersion": "1.3.14+generate-requirements-2.0.0",
-      "command": "bun test src/commands/barrel.test.ts src/commands/command-spec.test.ts src/mcp-schema-parity.test.ts src/index.test.ts --timeout=20000 --parallel=4 && bun test --timeout=20000 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
-      "requirementsSha256": "79b8d78ceb8690add5f4675da39b2913747b342266ea3f8695ff748642f59e78",
-      "sourceCommit": "02a09a3ca6b16b1ce803f9bc1e1b213961a013f4",
-      "generatedAt": "2026-08-08T04:49:24Z",
+      "command": "bun test src/core/framework-conventions.test.ts src/commands/naming.test.ts src/commands/organise.test.ts src/commands/barrel.test.ts --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
+      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
+      "sourceCommit": "0f748f3a0b2d092e39d7902e295106ad3447194c",
+      "generatedAt": "2026-08-08T05:19:41Z",
       "counts": {
-        "checked": 40,
+        "checked": 42,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "The barrel, command-specification, MCP parity, and library focus passed 62 tests with 0 failures and 397 assertions across 4 files.",
-        "The repository-guide canonical complete Bun suite passed 936 tests with 0 failures and 2605 assertions across 69 files; the guarded commit additionally passed 65 affected tests with 0 failures and 404 assertions across 5 files.",
-        "Exploratory full-suite runs with forced four-way parallelism produced rotating unrelated 20-second timeouts; each sampled timeout passed in isolation before the canonical sequential full suite passed.",
-        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed against source commit 02a09a3.",
+        "The framework-convention, naming, organise, and barrel focus passed 57 tests with 0 failures and 220 assertions across 4 files.",
+        "The complete Bun suite passed 942 tests with 0 failures and 2672 assertions across 70 files using the hook-required four-way parallelism; the guarded implementation commit additionally passed 138 affected tests with 0 failures and 718 assertions across 9 files.",
+        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed against source commit 0f748f3.",
         "MOVE-001 through MOVE-003 map to src/commands/move.test.ts and src/commands/move.ts at source commit 52106e7.",
         "TIDY-001, TIDY-002, and ROLL-001 map to src/commands/tidy.test.ts, src/core/rollback.test.ts, src/commands/tidy.ts, and src/core/rollback.ts at source commit 52106e7.",
         "CFG-001 through CFG-006 map to src/core/project-config.test.ts, src/commands/config-defaults.test.ts, src/commands/discover.test.ts, and their corresponding implementation files at source commit 52106e7.",
@@ -75,7 +74,7 @@
         "BATCH-001 through BATCH-005 map to src/commands/move-batch.test.ts and src/commands/move-batch.ts at source commit 52106e7.",
         "BATCH-006 and BATCH-007 map to src/mcp-server.ts plus src/mcp-schema-parity.test.ts at source commit 52106e7; these are explicit implementation locators in place of BDD anchors.",
         "AUDIT-001 through AUDIT-004 map to src/commands/audit.test.ts, src/commands/audit.ts, and src/mcp-server.ts at source commit 52106e7.",
-        "NAM-001 through NAM-003 map to src/commands/naming.test.ts, src/commands/naming.ts, src/commands/registry.ts, src/mcp-server.ts, src/types/naming.ts, and src/index.test.ts; 50 focused tests passed with 0 failures and 154 assertions.",
+        "NAM-001 through NAM-005 map to src/core/framework-conventions.ts, src/core/framework-conventions.test.ts, src/commands/naming.test.ts, src/commands/naming.ts, src/commands/registry.ts, src/mcp-server.ts, src/types/naming.ts, and src/index.test.ts; the direct framework and naming focus passed 30 tests with 0 failures and 157 assertions.",
         "JOUR-001 and JOUR-002 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/journal-integration.test.ts, the move, rename, alias, tidy, MCP, registry, and library surfaces.",
         "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts.",
         "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit 7016141.",
@@ -84,28 +83,28 @@
     }
   },
   "metrics": {
-    "totalScenarios": 40,
+    "totalScenarios": 42,
     "byDelivery": {
-      "V1": 40,
+      "V1": 42,
       "V2": 0,
       "LATER": 0,
       "UNSLICED": 0
     },
     "byDecision": {
-      "DECIDED": 40,
+      "DECIDED": 42,
       "OPEN": 0
     },
     "byPriority": {
       "P0": 4,
-      "P1": 24,
-      "P2": 12,
+      "P1": 25,
+      "P2": 13,
       "P3": 0
     },
     "priorityByDelivery": {
       "V1": {
         "P0": 4,
-        "P1": 24,
-        "P2": 12,
+        "P1": 25,
+        "P2": 13,
         "P3": 0
       },
       "V2": {
@@ -128,15 +127,15 @@
       }
     },
     "byFidelity": {
-      "VERIFIED": 40,
+      "VERIFIED": 42,
       "DRIFTED": 0,
       "MISSING": 0,
       "UNTESTABLE": 0
     },
     "coverage": {
       "v1Decided": {
-        "eligible": 40,
-        "verified": 40,
+        "eligible": 42,
+        "verified": 42,
         "percentage": 100
       },
       "v1LaunchCritical": {
@@ -178,8 +177,8 @@
     "fidelityNoteMismatchIds": [],
     "orphanAnchorIds": [],
     "preamble": {
-      "linesBeforeFirstScenario": 105,
-      "percentageBeforeFirstScenario": 21.9,
+      "linesBeforeFirstScenario": 106,
+      "percentageBeforeFirstScenario": 21.2,
       "warning": false,
       "disposition": null
     },

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -9,7 +9,7 @@
 
 ## Product Ground Truth
 
-Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, source-focused read-only analysis, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
+Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, framework-aware naming safety, source-focused read-only analysis, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
 
 ## Source Register
 
@@ -28,12 +28,13 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | SRC-011 | Repository owner issue | 2026-08-05 re-grounding | https://github.com/mherod/resect/issues/134 | Opt-in operation journal, guarded user-initiated undo, retention cap, and public-surface parity |
 | SRC-012 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/190 | Framework-generated TypeScript exclusion across audit, naming, and unused analysis |
 | SRC-013 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/189 | Framework metadata entrypoint treatment in barrel inventory and unused findings |
+| SRC-014 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/179 | No-op and framework-convention filename safety across naming reports and fixes |
 
 ## Delivery and Decision Register
 
 | Decision ID | Decision | State | Delivery | Sources | Reversal condition |
 |---|---|---|---|---|---|
-| DR-001 | This baseline covers the twelve accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013 | A repository-owner decision expands or retires the baseline. |
+| DR-001 | This baseline covers the thirteen accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013, SRC-014 | A repository-owner decision expands or retires the baseline. |
 | DR-002 | Resect is a local developer tool without accounts, tenants, sessions, notifications, analytics, or media. | DECIDED | V1 | SRC-007 | A published contract adds one of these product surfaces. |
 | DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009 | The execution model moves into a managed remote sandbox. |
 | DR-004 | Batch moves are sequential within one process and use one setup, worktree guard, and verification boundary. | DECIDED | V1 | SRC-006 | A repository-owner decision introduces parallel or cross-process coordination. |
@@ -44,8 +45,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Actor | Access scope and capabilities | Limitation and direct-attempt coverage | Passive perspective |
 |---|---|---|---|
-| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, and unsafe undo attempts are refused or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004. | Resolved configuration, previews, journal identifiers, target-casing findings, source-focused metrics, generated-artifact exclusions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, BARL-001, BARL-002. |
-| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, target-casing findings, audit exclusions, generated-artifact exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002. |
+| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, unsafe undo attempts, and no-op or framework-reserved naming moves are refused or excluded; MOVE-002, CFG-004, BATCH-005, UNDO-004, NAM-005. | Resolved configuration, previews, journal identifiers, location-aware target-casing findings, source-focused metrics, generated-artifact exclusions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, BARL-001, BARL-002. |
+| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, location-aware target-casing findings, audit exclusions, generated-artifact exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, NAM-004, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002. |
 
 ## Actor Groups
 
@@ -68,14 +69,14 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Coverage row | Scenario IDs or N/A | Decision or rationale |
 |---|---|---|
 | Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001, BARL-001 | Journal, configuration, transform, batch, target-casing, and barrel-analysis entry points are explicit. |
-| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
-| Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002 | Successful mutations and reversals report the applied operation. |
+| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
+| Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002, NAM-005 | Successful mutations and reversals report the applied operation while excluded naming moves remain untouched. |
 | Cancel or alternative exit | UNDO-003, BATCH-001 | Dry-run is the non-mutating alternative. |
 | Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007 | Failure paths preserve truthful outcomes. |
 | Interruption and re-entry | JOUR-001, UNDO-001, TIDY-002, ROLL-001 | Journal state survives command boundaries, and interrupted verification restores the checkpoint when enabled. |
 | Illegal transitions | UNDO-004, UNDO-005, CFG-004, BATCH-005, BATCH-007 | Invalid inputs and unsafe or unavailable reversals fail before mutation. |
 | LIFE-NA-001 — System-driven transitions | N/A — commands run only on caller invocation | Decision: DR-002 |
-| Side effects | JOUR-001, UNDO-001, MOVE-001, BATCH-003, NAM-002 | Journal state and importer updates remain consistent with file mutations and reversals. |
+| Side effects | JOUR-001, UNDO-001, MOVE-001, BATCH-003, NAM-002, NAM-005 | Journal state and importer updates remain consistent with file mutations and reversals, while no-op and framework-reserved filenames remain unchanged. |
 | Reversibility | UNDO-001, UNDO-002, TIDY-002, ROLL-001 | User-initiated undo and failure rollback restore the recorded pre-run state. |
 | LIFE-NA-002 — Subject and observer perspectives | N/A — no action targets another account or tenant | Decision: DR-002 |
 | Journal entry lifecycle | JOUR-001, JOUR-002, UNDO-001, UNDO-002, UNDO-005 | Entries move from recorded to retained, selected, restored, or unavailable. |
@@ -91,14 +92,14 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Security, session expiry or revocation, and abuse | APPLIES | TRNS-003 | Transform configs execute with host process privileges, so the consumer is warned before execution; SRC-009, DR-003. |
 | Audit and accountability | APPLIES | JOUR-001 | An opt-in local operation history identifies the command, inputs, timestamp, and affected files; SRC-011, DR-006. |
 | Notifications and communication preferences | N/A | — | No notification channel or preference model; DR-002; XC-NA-005. |
-| Search and discovery | APPLIES | CFG-001, CFG-005, AUDIT-001, ANLY-001, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
+| Search and discovery | APPLIES | CFG-001, CFG-005, NAM-004, AUDIT-001, ANLY-001, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
 | Empty and first-run states | APPLIES | UNDO-005, CFG-006, BATCH-005, BATCH-007 | Missing undo history and config are handled explicitly, and empty batches are rejected. |
 | Limits, quotas, and upgrade or denial behavior | APPLIES | JOUR-002 | Local operation history has a fixed retention limit without a plan or upgrade model; DR-006. |
 | Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004 | Mutating and reversal failures report truthfully and preserve later work unless explicitly forced. |
 | Persistence, interruption, and re-entry | APPLIES | JOUR-001, UNDO-001, UNDO-002, TIDY-002, ROLL-001 | Journal entries persist across command invocations and support a later guarded reversal. |
 | Data lifecycle, retention, deletion, and export | APPLIES | JOUR-002 | Operation history retains only the newest 20 entries; SRC-011, DR-006. |
 | Analytics and telemetry | N/A | — | No analytics or telemetry surface in baseline; DR-002; XC-NA-008. |
-| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, BARL-001, BARL-002 | Config and graph state are refreshed at their documented boundaries, and read-only analysis distinguishes authored structure from framework-consumed entrypoints and generated artifacts. |
+| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, BARL-001, BARL-002 | Config and graph state are refreshed at their documented boundaries, and read-only analysis distinguishes authored structure from framework-consumed entrypoints and generated artifacts. |
 | Media alternatives, captions, transcripts, and reduced motion | N/A | — | No media or motion surface; DR-002; XC-NA-009. |
 
 ## Feature: Safe Refactor Mutation and Rollback
@@ -392,6 +393,24 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 **Then** the target casing determines the findings
 **And** the result warns that the majority threshold was ignored
 
+### NAM-004 — Naming Consumer — Exclude valid framework-convention filenames from casing findings
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-014
+
+**Given** a valid Next.js routing or metadata code filename in its documented App Router location and a same-stem ordinary file elsewhere
+**When** a Naming Consumer audits naming through a human-readable or structured surface
+**Then** the valid framework-convention filename is absent from casing findings
+**And** the ordinary file remains eligible for a casing finding
+
+### NAM-005 — Operator — Prevent no-op and framework-convention rename attempts
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P2 | **Fidelity:** VERIFIED | **Sources:** SRC-010, SRC-014
+
+**Given** a project contains a no-op candidate, a valid framework-convention filename, and an actionable casing mismatch
+**When** the Operator requests a naming fix
+**Then** no no-op or framework-convention rename is attempted
+**And** the actionable mismatch remains available to plan or apply
+
 ## Feature: Source-Focused Audit Metrics
 
 ### AUDIT-001 — Operator — Exclude configured build output from source metrics
@@ -472,8 +491,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Layer | Status | Receipt | Current artifact |
 |---|---|---|---|
-| Structure | PASS | STRUCT-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
-| Document quality | PASS | QUALITY-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
-| Implementation | PASS | IMPL-20260808-002 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
+| Structure | PASS | STRUCT-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
+| Document quality | PASS | QUALITY-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
+| Implementation | PASS | IMPL-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
 
 The canonical validator, manual product-contract review, and focused implementation audit are independent. Counts, hashes, source commit, commands, timestamps, warning dispositions, and evidence summaries live only in the derived status artifact.

--- a/src/commands/naming.test.ts
+++ b/src/commands/naming.test.ts
@@ -78,6 +78,13 @@ const PASCAL_FUNCTION_NAMES = [
 	"RenderPanel",
 ] as const;
 
+const NEXT_METADATA_CODE_FILES = [
+	"apple-icon.tsx",
+	"icon.tsx",
+	"manifest.ts",
+	"robots.ts",
+] as const;
+
 async function makeFixture(name: string, files: Record<string, string>) {
 	return makeFixtureBase(`naming-${name}`, files, { tsconfig: true });
 }
@@ -377,7 +384,17 @@ describe("naming command", () => {
 
 	test("exempts Next.js reserved filenames inside an app router tree", async () => {
 		const dir = await makeFixture("reserved-app", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { jsx: "preserve", strict: true },
+				include: ["**/*.ts", "**/*.tsx"],
+			}),
 			...withFiles(CAMEL_NAMES, functionFile),
+			...Object.fromEntries(
+				NEXT_METADATA_CODE_FILES.map((file) => [
+					`src/app/${file}`,
+					functionFile("metadata"),
+				])
+			),
 			"src/app/not-found.tsx":
 				"export default function NotFound() { return null; }\n",
 			"src/app/route.ts": "export function GET() { return 1; }\n",
@@ -400,6 +417,95 @@ describe("naming command", () => {
 		expect(flagged).not.toContain("not-found.tsx");
 		expect(flagged).not.toContain("route.ts");
 		expect(flagged).not.toContain("global-error.tsx");
+		for (const file of NEXT_METADATA_CODE_FILES) {
+			expect(flagged).not.toContain(file);
+		}
+
+		await cleanup(dir);
+	});
+
+	test("keeps metadata stems eligible outside valid App Router locations", async () => {
+		const dir = await makeFixture("metadata-nonframework", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { jsx: "preserve", strict: true },
+				include: ["**/*.ts", "**/*.tsx"],
+			}),
+			...Object.fromEntries(
+				NEXT_METADATA_CODE_FILES.map((file) => [
+					`src/group/${file}`,
+					functionFile("metadata"),
+				])
+			),
+			"src/app/blog/manifest.ts": functionFile("manifest"),
+			"src/app/blog/robots.ts": functionFile("robots"),
+		});
+
+		const result = await captureOutput(async () =>
+			namingCommand({
+				directory: path.join(dir, "src"),
+				case: "PascalCase",
+				json: true,
+			})
+		);
+		const report = JSON.parse(result.stdout) as {
+			findings: Array<{ file: string; suggestedName: string }>;
+		};
+		const findings = new Map(
+			report.findings.map((finding) => [finding.file, finding.suggestedName])
+		);
+
+		expect(findings.get("group/apple-icon.tsx")).toBe("AppleIcon.tsx");
+		expect(findings.get("group/icon.tsx")).toBe("Icon.tsx");
+		expect(findings.get("group/manifest.ts")).toBe("Manifest.ts");
+		expect(findings.get("group/robots.ts")).toBe("Robots.ts");
+		expect(findings.get("app/blog/manifest.ts")).toBe("Manifest.ts");
+		expect(findings.get("app/blog/robots.ts")).toBe("Robots.ts");
+
+		await cleanup(dir);
+	});
+
+	// @BDD: NAM-004-Verified
+	test("filters the same metadata findings from JSON and human reports", async () => {
+		const dir = await makeFixture("metadata-output-parity", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { jsx: "preserve", strict: true },
+				include: ["**/*.ts", "**/*.tsx"],
+			}),
+			...Object.fromEntries(
+				NEXT_METADATA_CODE_FILES.flatMap((file) => [
+					[`src/app/${file}`, functionFile("frameworkMetadata")],
+					[`src/group/${file}`, functionFile("ordinaryMetadata")],
+				])
+			),
+		});
+
+		const jsonResult = await captureOutput(async () =>
+			namingCommand({
+				directory: path.join(dir, "src"),
+				case: "PascalCase",
+				json: true,
+			})
+		);
+		const report = JSON.parse(jsonResult.stdout) as {
+			findings: Array<{ file: string; suggestedName: string }>;
+		};
+		expect(report.findings.map((finding) => finding.file)).toEqual(
+			NEXT_METADATA_CODE_FILES.map((file) => `group/${file}`)
+		);
+
+		const humanResult = await captureOutput(async () =>
+			namingCommand({
+				directory: path.join(dir, "src"),
+				case: "PascalCase",
+			})
+		);
+		expect(humanResult.stdout).toContain("Summary: 4 finding(s)");
+		expect(humanResult.stdout).not.toContain("\napp\n");
+		for (const finding of report.findings) {
+			expect(humanResult.stdout).toContain(
+				`${path.basename(finding.file)} -> ${finding.suggestedName}`
+			);
+		}
 
 		await cleanup(dir);
 	});
@@ -462,13 +568,23 @@ describe("naming command", () => {
 		await cleanup(dir);
 	});
 
+	// @BDD: NAM-005-Verified
 	test("--fix never plans a no-op or reserved-file rename", async () => {
 		const dir = await makeGitFixture("fix-reserved", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { jsx: "preserve", strict: true },
+				include: ["**/*.ts", "**/*.tsx"],
+			}),
 			...withFiles(CAMEL_NAMES, functionFile),
+			...Object.fromEntries(
+				NEXT_METADATA_CODE_FILES.map((file) => [
+					`src/app/${file}`,
+					functionFile("metadata"),
+				])
+			),
 			"src/app/not-found.tsx":
 				"export default function NotFound() { return null; }\n",
 			"src/app/route.ts": "export function GET() { return 1; }\n",
-			"src/app/index.ts": "export const appIndex = 1;\n",
 			"src/app/my-widget.ts": functionFile("myWidget"),
 		});
 
@@ -478,7 +594,7 @@ describe("naming command", () => {
 				fix: true,
 				dryRun: true,
 				json: true,
-				case: "camelCase",
+				case: "PascalCase",
 			})
 		);
 		const out = JSON.parse(result.stdout) as {
@@ -490,7 +606,9 @@ describe("naming command", () => {
 		const planned = out.renames.map((r) => path.basename(r.from));
 		expect(planned).not.toContain("not-found.tsx");
 		expect(planned).not.toContain("route.ts");
-		expect(planned).not.toContain("index.ts");
+		for (const file of NEXT_METADATA_CODE_FILES) {
+			expect(planned).not.toContain(file);
+		}
 		expect(planned).toContain("my-widget.ts");
 
 		await cleanup(dir);

--- a/src/core/framework-conventions.test.ts
+++ b/src/core/framework-conventions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import {
+	hasAppRouterRootSegment,
+	isFrameworkConventionFile,
+} from "./framework-conventions.ts";
+
+const ROUTE_SEGMENT_CONVENTION_STEMS = [
+	"apple-icon",
+	"default",
+	"error",
+	"icon",
+	"layout",
+	"loading",
+	"not-found",
+	"opengraph-image",
+	"page",
+	"route",
+	"sitemap",
+	"template",
+	"twitter-image",
+] as const;
+
+const APP_ROOT_CONVENTION_STEMS = [
+	"global-error",
+	"manifest",
+	"robots",
+] as const;
+
+describe("framework conventions", () => {
+	test("recognizes route-segment conventions throughout an App Router tree", () => {
+		for (const stem of ROUTE_SEGMENT_CONVENTION_STEMS) {
+			expect(
+				isFrameworkConventionFile(
+					path.join("repo", "src", "app", "blog", `${stem}.tsx`)
+				)
+			).toBeTrue();
+		}
+	});
+
+	test("recognizes root-only conventions only at the App Router root", () => {
+		for (const stem of APP_ROOT_CONVENTION_STEMS) {
+			expect(
+				isFrameworkConventionFile(
+					path.join("repo", "src", "app", `${stem}.tsx`)
+				)
+			).toBeTrue();
+			expect(
+				isFrameworkConventionFile(
+					path.join("repo", "src", "app", "blog", `${stem}.tsx`)
+				)
+			).toBeFalse();
+		}
+	});
+
+	test("keeps convention stems ordinary outside an App Router tree", () => {
+		for (const stem of [
+			...ROUTE_SEGMENT_CONVENTION_STEMS,
+			...APP_ROOT_CONVENTION_STEMS,
+		]) {
+			expect(
+				isFrameworkConventionFile(
+					path.join("repo", "src", "lib", `${stem}.tsx`)
+				)
+			).toBeFalse();
+		}
+	});
+
+	test("does not mistake a workspace package named app for an App Router root", () => {
+		const file = path.join("repo", "packages", "app", "lib", "apple-icon.tsx");
+		expect(hasAppRouterRootSegment(file)).toBeFalse();
+		expect(isFrameworkConventionFile(file)).toBeFalse();
+	});
+});

--- a/src/core/framework-conventions.ts
+++ b/src/core/framework-conventions.ts
@@ -1,24 +1,32 @@
 import path from "node:path";
 
+type AppRouterConventionScope = "app-root" | "route-segment";
+
 /**
- * Next.js App Router filenames whose meaning comes from their name and position
- * in the route tree rather than from what they export.
+ * Next.js App Router code filenames whose meaning comes from their name and
+ * position rather than from what they export. The scope keeps root-only
+ * conventions from exempting ordinary same-stem files in nested route segments.
  *
  * https://nextjs.org/docs/app/getting-started/project-structure
+ * https://nextjs.org/docs/app/api-reference/file-conventions/metadata
  */
-const NEXT_APP_ROUTER_STEMS = new Set([
-	"default",
-	"error",
-	"global-error",
-	"layout",
-	"loading",
-	"not-found",
-	"opengraph-image",
-	"page",
-	"route",
-	"sitemap",
-	"template",
-	"twitter-image",
+const NEXT_APP_ROUTER_CONVENTIONS = new Map<string, AppRouterConventionScope>([
+	["apple-icon", "route-segment"],
+	["default", "route-segment"],
+	["error", "route-segment"],
+	["global-error", "app-root"],
+	["icon", "route-segment"],
+	["layout", "route-segment"],
+	["loading", "route-segment"],
+	["manifest", "app-root"],
+	["not-found", "route-segment"],
+	["opengraph-image", "route-segment"],
+	["page", "route-segment"],
+	["robots", "app-root"],
+	["route", "route-segment"],
+	["sitemap", "route-segment"],
+	["template", "route-segment"],
+	["twitter-image", "route-segment"],
 ]);
 
 /**
@@ -42,15 +50,18 @@ const WORKSPACE_CONTAINER_SEGMENTS = new Set([
  * recognised while rejecting the package-name case. This only ever narrows the
  * exemption, so it cannot create a new one.
  */
-export function hasAppRouterRootSegment(filePath: string): boolean {
-	const segments = filePath.split(path.sep);
-	return segments.some((segment, index) => {
+function findAppRouterRootSegmentIndex(segments: string[]): number {
+	return segments.findIndex((segment, index) => {
 		if (segment !== "app") {
 			return false;
 		}
 		const parent = segments[index - 1];
 		return parent === undefined || !WORKSPACE_CONTAINER_SEGMENTS.has(parent);
 	});
+}
+
+export function hasAppRouterRootSegment(filePath: string): boolean {
+	return findAppRouterRootSegmentIndex(filePath.split(path.sep)) !== -1;
 }
 
 /**
@@ -105,7 +116,16 @@ export function isFrameworkConventionFile(
 	stem?: string
 ): boolean {
 	const resolvedStem = stem ?? path.basename(filePath, path.extname(filePath));
-	return (
-		NEXT_APP_ROUTER_STEMS.has(resolvedStem) && hasAppRouterRootSegment(filePath)
-	);
+	const scope = NEXT_APP_ROUTER_CONVENTIONS.get(resolvedStem);
+	if (!scope) {
+		return false;
+	}
+
+	const segments = filePath.split(path.sep);
+	const appRootIndex = findAppRouterRootSegmentIndex(segments);
+	if (appRootIndex === -1) {
+		return false;
+	}
+
+	return scope === "route-segment" || appRootIndex === segments.length - 2;
 }


### PR DESCRIPTION
## Summary
- centralize Next.js App Router code filename conventions in one location-aware table
- suppress no-op and valid framework-convention casing findings while keeping ordinary or invalid-location same-stem files eligible
- keep human, JSON, and apply planning behavior aligned and register the guarantees as NAM-004 and NAM-005

## What changed
- distinguish route-segment conventions from app-root-only conventions such as manifest and robots
- cover apple-icon, icon, manifest, and robots across valid App Router locations and non-framework controls
- add table-driven core tests plus naming output-parity and dry-run mutation-safety coverage
- update SRC-014 and the structure, document-quality, and implementation receipts

## Verification
- red baseline: 5 expected regression failures before the classifier change
- bun test src/core/framework-conventions.test.ts src/commands/naming.test.ts src/commands/organise.test.ts src/commands/barrel.test.ts --parallel=4 (57 pass, 0 fail, 220 assertions)
- bun test --timeout=20000 --parallel=4 (942 pass, 0 fail, 2672 assertions across 70 files)
- pnpm run check
- pnpm run lint
- pnpm run typecheck
- pnpm run build:lib
- pnpm run verify:size
- canonical requirements migration check and validator (42 scenarios, 0 errors)

## Risk / rollout
Low. The classifier is shared by naming, organise, and barrel analysis, so the change is intentionally centralized; focused coverage exercises all three consumers and preserves ordinary same-stem behavior outside valid App Router contexts.

Closes #179