### PR TITLE
fix(analyze): protect convention entrypoints

### DIFF
--- a/.requirements-status.json
+++ b/.requirements-status.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "projectId": "mherod/resect",
   "requirementsFile": "REQUIREMENTS.md",
-  "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
-  "sourceCommit": "dc4c1d425f0911787a8753b2380eaa60447beaad",
-  "generatedAt": "2026-08-08T05:38:52Z",
+  "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
+  "sourceCommit": "045be4d077669d24f9fe52e6dd1b22ceb3e7ac7f",
+  "generatedAt": "2026-08-08T06:05:08Z",
   "validator": {
     "name": "generate-requirements",
     "version": "2.0.0",
@@ -13,15 +13,15 @@
   "validation": {
     "structure": {
       "status": "PASS",
-      "receiptId": "STRUCT-20260808-003",
+      "receiptId": "STRUCT-20260808-004",
       "validator": "validate-bdd",
       "validatorVersion": "2.0.0",
       "command": "bun scripts/validate-bdd.js /Users/matthew.herod/Development/resect/REQUIREMENTS.md --status-log /Users/matthew.herod/Development/resect/.requirements-status.json",
-      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
-      "sourceCommit": "dc4c1d425f0911787a8753b2380eaa60447beaad",
-      "generatedAt": "2026-08-08T05:38:52Z",
+      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
+      "sourceCommit": "045be4d077669d24f9fe52e6dd1b22ceb3e7ac7f",
+      "generatedAt": "2026-08-08T06:05:08Z",
       "counts": {
-        "checked": 42,
+        "checked": 44,
         "errors": 0,
         "warnings": 0
       },
@@ -31,41 +31,42 @@
     },
     "documentQuality": {
       "status": "PASS",
-      "receiptId": "QUALITY-20260808-003",
+      "receiptId": "QUALITY-20260808-004",
       "validator": "generate-requirements-manual-review",
       "validatorVersion": "2.0.0",
       "command": "generate-requirements 2.0 manual review of REQUIREMENTS.md",
-      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
-      "sourceCommit": "dc4c1d425f0911787a8753b2380eaa60447beaad",
-      "generatedAt": "2026-08-08T05:38:52Z",
+      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
+      "sourceCommit": "045be4d077669d24f9fe52e6dd1b22ceb3e7ac7f",
+      "generatedAt": "2026-08-08T06:05:08Z",
       "counts": {
-        "checked": 42,
+        "checked": 44,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "Reviewed all 42 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
-        "Framework-aware naming safety is explicit across human-readable and structured findings, valid App Router locations, ordinary and invalid-location controls, no-op suppression, and apply planning; no preamble or priority-skew warning was computed."
+        "Reviewed all 44 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
+        "Framework-dispatched entrypoint safety is explicit across built-in valid App Router locations, ordinary same-stem controls, caller-configured globs, human-readable advice, and structured CLI, MCP, and library results.",
+        "Reviewed the V1/P1 priority concentration: the 27 source-backed P1 scenarios represent important non-critical safety and parity behavior, while the four launch-critical scenarios remain P0; retain the independently grounded priorities."
       ]
     },
     "implementation": {
       "status": "PASS",
-      "receiptId": "IMPL-20260808-003",
+      "receiptId": "IMPL-20260808-004",
       "validator": "bun-test-plus-clause-audit",
       "validatorVersion": "1.3.14+generate-requirements-2.0.0",
-      "command": "bun test src/core/framework-conventions.test.ts src/commands/naming.test.ts src/commands/organise.test.ts src/commands/barrel.test.ts --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
-      "requirementsSha256": "0c24c3789050de5062e8a231474e57311391308f74b7d4218b0fb666684f72c1",
-      "sourceCommit": "dc4c1d425f0911787a8753b2380eaa60447beaad",
-      "generatedAt": "2026-08-08T05:38:52Z",
+      "command": "bun test --timeout=20000 src/core/framework-conventions.test.ts src/commands/analyze.test.ts src/commands/unused.test.ts src/mcp-entrypoints.test.ts src/mcp-schema-parity.test.ts --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
+      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
+      "sourceCommit": "045be4d077669d24f9fe52e6dd1b22ceb3e7ac7f",
+      "generatedAt": "2026-08-08T06:05:08Z",
       "counts": {
-        "checked": 42,
+        "checked": 44,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "The framework-convention, naming, organise, and barrel focus passed 57 tests with 0 failures and 220 assertions across 4 files.",
-        "The complete Bun suite passed 942 tests with 0 failures and 2672 assertions across 70 files using the hook-required four-way parallelism; the guarded implementation commit additionally passed 138 affected tests with 0 failures and 718 assertions across 9 files.",
-        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, and the configured tarball-size preflight passed; post-merge CI run 31241924254 revalidated typecheck, lint, the full suite, and package size against source commit dc4c1d4.",
+        "The framework convention, analyze, unused, and MCP focus passed 73 tests with 0 failures and 344 assertions across 5 files.",
+        "The complete Bun suite passed 947 tests with 0 failures across 71 files using the hook-required four-way parallelism; the guarded implementation commit additionally passed 716 affected tests with 0 failures and 2347 assertions across 57 files.",
+        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, the supported global install, and the configured tarball-size preflight passed at source commit 045be4d.",
         "MOVE-001 through MOVE-003 map to src/commands/move.test.ts and src/commands/move.ts at source commit 52106e7.",
         "TIDY-001, TIDY-002, and ROLL-001 map to src/commands/tidy.test.ts, src/core/rollback.test.ts, src/commands/tidy.ts, and src/core/rollback.ts at source commit 52106e7.",
         "CFG-001 through CFG-006 map to src/core/project-config.test.ts, src/commands/config-defaults.test.ts, src/commands/discover.test.ts, and their corresponding implementation files at source commit 52106e7.",
@@ -78,32 +79,33 @@
         "JOUR-001 and JOUR-002 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/journal-integration.test.ts, the move, rename, alias, tidy, MCP, registry, and library surfaces.",
         "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts.",
         "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit dc4c1d4.",
+        "ANLY-003 and ANLY-004 map to src/core/framework-conventions.ts, src/core/framework-conventions.test.ts, src/commands/analyze.test.ts, src/commands/unused.test.ts, src/mcp-entrypoints.test.ts, src/mcp-schema-parity.test.ts, src/mcp-server.ts, and src/index.ts at source commit 045be4d.",
         "BARL-001 and BARL-002 map to src/core/framework-conventions.ts, src/commands/barrel.ts, src/commands/barrel.test.ts, src/mcp-server.ts, and src/index.test.ts at source commit dc4c1d4."
       ]
     }
   },
   "metrics": {
-    "totalScenarios": 42,
+    "totalScenarios": 44,
     "byDelivery": {
-      "V1": 42,
+      "V1": 44,
       "V2": 0,
       "LATER": 0,
       "UNSLICED": 0
     },
     "byDecision": {
-      "DECIDED": 42,
+      "DECIDED": 44,
       "OPEN": 0
     },
     "byPriority": {
       "P0": 4,
-      "P1": 25,
+      "P1": 27,
       "P2": 13,
       "P3": 0
     },
     "priorityByDelivery": {
       "V1": {
         "P0": 4,
-        "P1": 25,
+        "P1": 27,
         "P2": 13,
         "P3": 0
       },
@@ -127,15 +129,15 @@
       }
     },
     "byFidelity": {
-      "VERIFIED": 42,
+      "VERIFIED": 44,
       "DRIFTED": 0,
       "MISSING": 0,
       "UNTESTABLE": 0
     },
     "coverage": {
       "v1Decided": {
-        "eligible": 42,
-        "verified": 42,
+        "eligible": 44,
+        "verified": 44,
         "percentage": 100
       },
       "v1LaunchCritical": {
@@ -177,12 +179,20 @@
     "fidelityNoteMismatchIds": [],
     "orphanAnchorIds": [],
     "preamble": {
-      "linesBeforeFirstScenario": 106,
-      "percentageBeforeFirstScenario": 21.2,
+      "linesBeforeFirstScenario": 107,
+      "percentageBeforeFirstScenario": 20.7,
       "warning": false,
       "disposition": null
     },
-    "prioritySkew": []
+    "prioritySkew": [
+      {
+        "delivery": "V1",
+        "tier": "P1",
+        "percentage": 61.4,
+        "warning": true,
+        "disposition": "Retain the independently grounded priorities: the 27 P1 scenarios are important non-critical safety and parity behavior, while the four launch-critical scenarios remain P0."
+      }
+    ]
   },
   "regressions": [],
   "retiredScenarioIds": []

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Understand a module's place in your codebase.
 ```bash
 resect analyze src/components/Button.tsx --verbose
 resect analyze src/core/resolver.ts -p .
+resect analyze hooks/dispatch.ts --entrypoint-globs="hooks/**"
 ```
 
 Shows:
@@ -324,6 +325,8 @@ Shows:
 - Barrel files that re-export this module
 - **Unresolvable imports** — specifiers that cannot be resolved, with line numbers and diagnostics
 - **Project-wide unresolvable imports** — all broken imports across the entire project, shown at the end
+
+Static imports cannot reveal exports invoked by a framework or manifest. `analyze` therefore treats recognized Next.js App Router files (for example `page`, `layout`, `route`, and metadata code files under `app/`) as externally consumed instead of recommending that their exports be deleted. Use repeatable `--entrypoint-globs` for custom filename-dispatched entrypoints such as hooks or scripts; the library and MCP surfaces accept the equivalent `entrypointGlobs` option and report `externalUsageAssumed: true`.
 
 ### `analyze-impact <source> <target>`
 
@@ -472,12 +475,15 @@ Find exports and files that no other file in the project imports.
 resect unused src                            # Scan for unused exports
 resect unused src --json                     # JSON output for tooling
 resect unused src --ignore="*.test.ts"       # Exclude test files
+resect unused . --entrypoint-globs="hooks/**" # Add custom entrypoints
 resect unused src --verbose                  # Detailed output
 ```
 
 A per-export hit is a **de-export** signal, not automatically a **delete** signal. Each result carries `internalUsage` / `internalRefCount`: when `internalUsage` is `false` the symbol is referenced nowhere and is safe to delete; when `true`, it is still called within its own file, so only the `export` keyword is redundant — deleting the symbol would break its own module. The report also returns aggregate `deadCount` and `internalOnlyCount`.
 
-The report also includes `orphanFiles`: exported files with `noExternalUsage:true`, meaning no external file imports the module or a barrel that re-exports it. Package entrypoints from `package.json` `main`, `module`, or `exports` are excluded from this list because they are public API by definition. This top-level JSON field is experimental during the 1.x series and is marked with `schemaVersion: "1-experimental"`.
+The report also includes `orphanFiles`: exported files with `noExternalUsage:true`, meaning no external file imports the module or a barrel that re-exports it. Package entrypoints from `package.json` `main`, `module`, or `exports` are excluded from this list because they are public API by definition. Recognized Next.js App Router code entrypoints and files matched by `--entrypoint-globs` are excluded from both unused-export and orphan-file verdicts; structured output records them as `excludedEntrypointFiles` / `excludedEntrypointFileCount`. This top-level JSON schema is experimental during the 1.x series and is marked with `schemaVersion: "1-experimental"`.
+
+This built-in handling is deliberately location-aware: an `app/api/example/route.ts` handler is framework-consumed, while an ordinary `lib/route.ts` remains analyzable. For frameworks, manifests, or dispatchers outside the built-in App Router conventions, configure one or more entrypoint globs rather than trusting static-import-only delete advice.
 
 Usage is counted across **every tsconfig discovered in the project**, not just the one that resolves for the scan directory — so an export consumed only by a sibling config (e.g. `scripts/` on a `tsconfig.scripts.json`) is not falsely reported dead. The scanned set is returned as `scannedConfigs` / `scannedFileCount`. The `--ignore` glob excludes files only as reported *candidates*; ignored files (e.g. tests) still count as *usage* sources, so a test-only export is not reported dead.
 
@@ -759,7 +765,7 @@ Under Bun the default runtime works out of the box; subpath entry points `@mhero
 | `--bucket` | | Restrict similar output to `exact`, `high`, or `medium` |
 | `--format` | | Output format for `similar`: `compact` |
 | `--ignore` | | Glob of files to exclude as reported candidates (unused/organise) |
-| `--entrypoint-globs` | | Extra globs treated as public entrypoints (unused); repeatable |
+| `--entrypoint-globs` | | Extra globs treated as public entrypoints (analyze/unused); repeatable |
 | `--fan-out-threshold` | | Flag files importing more than N modules (audit/tidy) |
 | `--fan-in-threshold` | | Flag files imported by more than N files (audit/tidy) |
 | `--export-threshold` | | Flag files exporting more than N symbols (audit/tidy) |

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -9,7 +9,7 @@
 
 ## Product Ground Truth
 
-Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, framework-aware naming safety, source-focused read-only analysis, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
+Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, framework-aware naming safety, source-focused read-only analysis, framework-dispatched entrypoint safety, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
 
 ## Source Register
 
@@ -29,12 +29,13 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | SRC-012 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/190 | Framework-generated TypeScript exclusion across audit, naming, and unused analysis |
 | SRC-013 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/189 | Framework metadata entrypoint treatment in barrel inventory and unused findings |
 | SRC-014 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/179 | No-op and framework-convention filename safety across naming reports and fixes |
+| SRC-015 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/150 | Framework convention entrypoint treatment in analyze and unused results |
 
 ## Delivery and Decision Register
 
 | Decision ID | Decision | State | Delivery | Sources | Reversal condition |
 |---|---|---|---|---|---|
-| DR-001 | This baseline covers the thirteen accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013, SRC-014 | A repository-owner decision expands or retires the baseline. |
+| DR-001 | This baseline covers the fourteen accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013, SRC-014, SRC-015 | A repository-owner decision expands or retires the baseline. |
 | DR-002 | Resect is a local developer tool without accounts, tenants, sessions, notifications, analytics, or media. | DECIDED | V1 | SRC-007 | A published contract adds one of these product surfaces. |
 | DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009 | The execution model moves into a managed remote sandbox. |
 | DR-004 | Batch moves are sequential within one process and use one setup, worktree guard, and verification boundary. | DECIDED | V1 | SRC-006 | A repository-owner decision introduces parallel or cross-process coordination. |
@@ -45,8 +46,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Actor | Access scope and capabilities | Limitation and direct-attempt coverage | Passive perspective |
 |---|---|---|---|
-| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, unsafe undo attempts, and no-op or framework-reserved naming moves are refused or excluded; MOVE-002, CFG-004, BATCH-005, UNDO-004, NAM-005. | Resolved configuration, previews, journal identifiers, location-aware target-casing findings, source-focused metrics, generated-artifact exclusions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, BARL-001, BARL-002. |
-| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, location-aware target-casing findings, audit exclusions, generated-artifact exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, NAM-004, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002. |
+| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, unsafe undo attempts, no-op or framework-reserved naming moves, and false delete advice for convention entrypoints are refused or excluded; MOVE-002, CFG-004, BATCH-005, UNDO-004, NAM-005, ANLY-003. | Resolved configuration, previews, journal identifiers, location-aware target-casing findings, source-focused metrics, generated-artifact exclusions, framework entrypoint assumptions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002. |
+| API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, location-aware target-casing findings, audit exclusions, generated-artifact exclusions, framework entrypoint assumptions and exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, NAM-004, AUDIT-004, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002. |
 
 ## Actor Groups
 
@@ -68,8 +69,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Coverage row | Scenario IDs or N/A | Decision or rationale |
 |---|---|---|
-| Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001, BARL-001 | Journal, configuration, transform, batch, target-casing, and barrel-analysis entry points are explicit. |
-| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
+| Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001, ANLY-003, ANLY-004, BARL-001 | Journal, configuration, transform, batch, target-casing, source-analysis, and barrel-analysis entry points are explicit. |
+| Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
 | Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002, NAM-005 | Successful mutations and reversals report the applied operation while excluded naming moves remain untouched. |
 | Cancel or alternative exit | UNDO-003, BATCH-001 | Dry-run is the non-mutating alternative. |
 | Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007 | Failure paths preserve truthful outcomes. |
@@ -92,14 +93,14 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Security, session expiry or revocation, and abuse | APPLIES | TRNS-003 | Transform configs execute with host process privileges, so the consumer is warned before execution; SRC-009, DR-003. |
 | Audit and accountability | APPLIES | JOUR-001 | An opt-in local operation history identifies the command, inputs, timestamp, and affected files; SRC-011, DR-006. |
 | Notifications and communication preferences | N/A | — | No notification channel or preference model; DR-002; XC-NA-005. |
-| Search and discovery | APPLIES | CFG-001, CFG-005, NAM-004, AUDIT-001, ANLY-001, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
+| Search and discovery | APPLIES | CFG-001, CFG-005, NAM-004, AUDIT-001, ANLY-001, ANLY-003, ANLY-004, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
 | Empty and first-run states | APPLIES | UNDO-005, CFG-006, BATCH-005, BATCH-007 | Missing undo history and config are handled explicitly, and empty batches are rejected. |
 | Limits, quotas, and upgrade or denial behavior | APPLIES | JOUR-002 | Local operation history has a fixed retention limit without a plan or upgrade model; DR-006. |
 | Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004 | Mutating and reversal failures report truthfully and preserve later work unless explicitly forced. |
 | Persistence, interruption, and re-entry | APPLIES | JOUR-001, UNDO-001, UNDO-002, TIDY-002, ROLL-001 | Journal entries persist across command invocations and support a later guarded reversal. |
 | Data lifecycle, retention, deletion, and export | APPLIES | JOUR-002 | Operation history retains only the newest 20 entries; SRC-011, DR-006. |
 | Analytics and telemetry | N/A | — | No analytics or telemetry surface in baseline; DR-002; XC-NA-008. |
-| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, BARL-001, BARL-002 | Config and graph state are refreshed at their documented boundaries, and read-only analysis distinguishes authored structure from framework-consumed entrypoints and generated artifacts. |
+| Performance, freshness, and stale-data behavior | APPLIES | CFG-001, BATCH-002, BATCH-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-003, ANLY-004, BARL-001, BARL-002 | Config and graph state are refreshed at their documented boundaries, and read-only analysis distinguishes authored structure from framework-consumed entrypoints and generated artifacts. |
 | Media alternatives, captions, transcripts, and reduced motion | N/A | — | No media or motion surface; DR-002; XC-NA-009. |
 
 ## Feature: Safe Refactor Mutation and Rollback
@@ -468,6 +469,24 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 **And** a warning explains that framework-generated TypeScript was excluded
 **And** a machine-readable result identifies the excluded paths
 
+### ANLY-003 — Analysis Consumer — Protect framework convention entrypoints from delete advice
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-015
+
+**Given** a recognized App Router entrypoint in a valid location and an ordinary same-stem module elsewhere
+**When** an Analysis Consumer runs analyze or unused source analysis
+**Then** the framework entrypoint is absent from unused-export, orphan-file, and delete verdicts
+**And** the ordinary module remains analyzable
+
+### ANLY-004 — Analysis Consumer — Configure an external entrypoint convention
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-015
+
+**Given** an authored source file matches a caller-configured entrypoint glob
+**When** an Analysis Consumer invokes the CLI, MCP, or library analysis surface with that convention
+**Then** the file is treated as externally consumed rather than unused or deletable
+**And** machine-readable results identify the assumed or excluded entrypoint consistently across surfaces
+
 ## Feature: Framework-Aware Barrel Analysis
 
 ### BARL-001 — Analysis Consumer — Scope unused findings around framework metadata entrypoints
@@ -491,8 +510,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Layer | Status | Receipt | Current artifact |
 |---|---|---|---|
-| Structure | PASS | STRUCT-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
-| Document quality | PASS | QUALITY-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
-| Implementation | PASS | IMPL-20260808-003 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
+| Structure | PASS | STRUCT-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
+| Document quality | PASS | QUALITY-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
+| Implementation | PASS | IMPL-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
 
 The canonical validator, manual product-contract review, and focused implementation audit are independent. Counts, hashes, source commit, commands, timestamps, warning dispositions, and evidence summaries live only in the derived status artifact.

--- a/src/commands/analyze.test.ts
+++ b/src/commands/analyze.test.ts
@@ -16,6 +16,7 @@ async function makeFixture(name: string, files: Record<string, string>) {
 }
 
 describe("analyze command", () => {
+	// @BDD: ANLY-003-Verified
 	test("treats App Router route handlers as externally consumed", async () => {
 		const dir = await makeFixtureBase("analyze-framework-entrypoint", {
 			"tsconfig.json": JSON.stringify({
@@ -49,6 +50,7 @@ describe("analyze command", () => {
 		}
 	});
 
+	// @BDD: ANLY-004-Verified
 	test("CLI analyze respects built-in and configured entrypoints", async () => {
 		const dir = await makeFixtureBase("analyze-configured-entrypoint", {
 			"tsconfig.json": JSON.stringify({

--- a/src/commands/analyze.test.ts
+++ b/src/commands/analyze.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
+import { loadProject } from "../core/project.ts";
 import { CLI, cleanup, makeFixture as makeFixtureBase } from "./__test-helpers";
+import { analyze } from "./analyze.ts";
 
 async function makeFixture(name: string, files: Record<string, string>) {
 	const dir = await makeFixtureBase(`analyze-${name}`, {
@@ -14,6 +16,72 @@ async function makeFixture(name: string, files: Record<string, string>) {
 }
 
 describe("analyze command", () => {
+	test("treats App Router route handlers as externally consumed", async () => {
+		const dir = await makeFixtureBase("analyze-framework-entrypoint", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true },
+				include: ["src/**/*.ts"],
+			}),
+			"src/app/api/example/route.ts": [
+				"export async function GET() { return Response.json({ ok: true }); }",
+				"export async function POST() { return Response.json({ ok: true }); }",
+			].join("\n"),
+			"src/lib/route.ts": "export function GET() { return 'ordinary'; }\n",
+		});
+		try {
+			const routeFile = path.join(dir, "src/app/api/example/route.ts");
+			const ordinaryFile = path.join(dir, "src/lib/route.ts");
+			const project = loadProject(path.join(dir, "tsconfig.json"), routeFile);
+
+			const routeResult = await analyze(routeFile, project);
+			expect(routeResult.externalUsageAssumed).toBeTrue();
+			expect(routeResult.unusedExports).toHaveLength(0);
+			expect(routeResult.noExternalUsage).toBeFalse();
+
+			const ordinaryResult = await analyze(ordinaryFile, project);
+			expect(ordinaryResult.externalUsageAssumed).toBeFalse();
+			expect(ordinaryResult.unusedExports.map((item) => item.name)).toContain(
+				"GET"
+			);
+			expect(ordinaryResult.noExternalUsage).toBeTrue();
+		} finally {
+			await cleanup(dir);
+		}
+	});
+
+	test("CLI analyze respects built-in and configured entrypoints", async () => {
+		const dir = await makeFixtureBase("analyze-configured-entrypoint", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true },
+				include: ["**/*.ts"],
+			}),
+			"app/api/example/route.ts": "export async function GET() {}\n",
+			"hooks/dispatch.ts": "export function runHook() {}\n",
+		});
+		try {
+			for (const args of [
+				[path.join(dir, "app/api/example/route.ts")],
+				[path.join(dir, "hooks/dispatch.ts"), "--entrypoint-globs=hooks/**"],
+			]) {
+				const proc = Bun.spawn([...CLI, "analyze", ...args], {
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+				const [stdout, stderr] = await Promise.all([
+					new Response(proc.stdout).text(),
+					new Response(proc.stderr).text(),
+				]);
+				await proc.exited;
+				expect(proc.exitCode, stderr).toBe(0);
+				expect(stdout).toContain("treated as externally consumed");
+				expect(stdout).not.toContain("delete (no refs)");
+				expect(stdout).not.toContain("No external usage");
+			}
+		} finally {
+			await cleanup(dir);
+		}
+	});
+
 	test("warns when project graph coverage is incomplete", async () => {
 		const dir = await makeFixture("skipped-file", {
 			"tsconfig.json": JSON.stringify({

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { logger } from "../cli-logger.ts";
 import {
+	type EntrypointGlobs,
+	isConventionEntrypointFile,
+} from "../core/framework-conventions.ts";
+import {
 	buildDependencyGraph,
 	buildProjectGraphs,
 	findAllReferences,
@@ -24,6 +28,11 @@ import { setupCommandContext } from "./command-context.ts";
 export interface AnalyzeOptions extends ReadOnlyCommandOptions {
 	file: string;
 	onlyRelatedTo?: string;
+	entrypointGlobs?: EntrypointGlobs;
+}
+
+export interface AnalyzeFileOptions {
+	entrypointGlobs?: EntrypointGlobs;
 }
 
 export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
@@ -33,6 +42,7 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 		project: projectArg,
 		workspace = false,
 		onlyRelatedTo,
+		entrypointGlobs,
 	} = options;
 
 	const absolutePath = path.resolve(file);
@@ -49,7 +59,7 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 	}
 
 	const { extraProjects, project, workspace: workspaceInfo } = context;
-	const result = await analyze(absolutePath, project);
+	const result = await analyze(absolutePath, project, { entrypointGlobs });
 
 	// When workspace mode is enabled, find cross-package references
 	if (workspace && workspaceInfo && workspaceInfo.packages.length > 0) {
@@ -103,7 +113,8 @@ export async function analyzeCommand(options: AnalyzeOptions): Promise<void> {
 
 export async function analyze(
 	filePath: string,
-	project: ProjectConfig
+	project: ProjectConfig,
+	options?: AnalyzeFileOptions
 ): Promise<AnalysisResult> {
 	// .vue files cannot be parsed via createProgram — use the Vue-aware parseSourceFile instead.
 	// For non-vue files, fall back to parseSourceFile if the program can't resolve the file
@@ -163,21 +174,28 @@ export async function analyze(
 	} = await import("./unused.ts");
 	const importedBindings = buildImportedBindingsMap(graph);
 	const fileImporters = importedBindings.get(filePath);
-	const unusedExports = exports
-		.filter((exp) => !isExportUsed(exp, filePath, fileImporters, graph))
-		.map((exp) => {
-			const internalRefCount = countInternalReferences(
-				sourceFile,
-				exp,
-				internalRefChecker
-			);
-			return {
-				...exp,
-				internalUsage: internalRefCount > 0,
-				internalRefCount,
-			};
-		});
-	const noExternalUsage = hasNoExternalUsage(filePath, exports, graph);
+	const externalUsageAssumed = isConventionEntrypointFile(
+		filePath,
+		options?.entrypointGlobs
+	);
+	const unusedExports = externalUsageAssumed
+		? []
+		: exports
+				.filter((exp) => !isExportUsed(exp, filePath, fileImporters, graph))
+				.map((exp) => {
+					const internalRefCount = countInternalReferences(
+						sourceFile,
+						exp,
+						internalRefChecker
+					);
+					return {
+						...exp,
+						internalUsage: internalRefCount > 0,
+						internalRefCount,
+					};
+				});
+	const noExternalUsage =
+		!externalUsageAssumed && hasNoExternalUsage(filePath, exports, graph);
 
 	return {
 		file: filePath,
@@ -188,6 +206,7 @@ export async function analyze(
 		unresolvable,
 		unusedExports,
 		noExternalUsage,
+		externalUsageAssumed,
 		skippedFiles: graph.skippedFiles,
 	};
 }
@@ -274,7 +293,12 @@ function printAnalysis(
 		logger.empty();
 	}
 
-	if (result.noExternalUsage) {
+	if (result.externalUsageAssumed) {
+		logger.info(
+			"Framework or configured entrypoint: exports are treated as externally consumed."
+		);
+		logger.empty();
+	} else if (result.noExternalUsage) {
 		logger.info(
 			"No external usage: every export in this file is unused outside the file."
 		);

--- a/src/commands/command-spec.ts
+++ b/src/commands/command-spec.ts
@@ -119,19 +119,22 @@ Options:
   -p, --project      Path to project directory or tsconfig.json
   --workspace        Scan across all workspace packages
   --only-related-to  Filter referencedBy results to a file, folder, or glob pattern
+  --entrypoint-globs Glob pattern(s) for externally dispatched entrypoints; repeatable
 
 Output includes:
   • All exports from the file
   • All imports used by the file
   • All files that reference this module
   • Barrel files that re-export this module
+  • Entrypoint classification that suppresses unsafe unused/delete advice
 
 Examples:
   ${CLI_NAME} analyze src/utils/helpers.ts
   ${CLI_NAME} analyze src/components/Button.tsx --verbose
+  ${CLI_NAME} analyze hooks/dispatch.ts --entrypoint-globs="hooks/**"
 `,
 		mcpDescription:
-			"Get the full dependency picture of ONE module before you edit, move, rename, or delete it. Reports the file's exports, its imports (with bindings and type-only flags), every file that references it (reverse dependencies — the blast radius of a change), barrel files that re-export it, imports that fail to resolve, and exports that no other file imports. Reach for this whenever you need to understand impact or wiring of a specific file; use `find` first if you only know the name. Pass a file, not a directory. Read-only.",
+			"Get the full dependency picture of ONE module before you edit, move, rename, or delete it. Reports the file's exports, its imports (with bindings and type-only flags), every file that references it (reverse dependencies — the blast radius of a change), barrel files that re-export it, imports that fail to resolve, and exports that no other file imports. Recognized App Router files and caller-supplied entrypoint globs are treated as externally consumed because static imports cannot observe framework dispatch. Reach for this whenever you need to understand impact or wiring of a specific file; use `find` first if you only know the name. Pass a file, not a directory. Read-only.",
 	},
 	{
 		name: "analyze-impact",
@@ -735,6 +738,8 @@ Options:
                         orphan/dead reporting (e.g. "hooks/**", "scripts/*.ts").
                         Repeat the flag for multiple patterns.
 
+Recognized Next.js App Router code entrypoints are excluded automatically.
+
 Examples:
   ${CLI_NAME} unused src
   ${CLI_NAME} unused . --json
@@ -744,7 +749,7 @@ Examples:
   ${CLI_NAME} unused src --entrypoint-globs="hooks/**" --entrypoint-globs="scripts/*.ts"
 `,
 		mcpDescription:
-			"Find exports that no OTHER file in the project imports, plus exported files with no external usage. A per-export hit is a DE-EXPORT signal, not automatically a DELETE signal: each entry carries `internalUsage`/`internalRefCount` telling you whether the symbol is still referenced WITHIN its own file. `internalUsage:false` (`internalRefCount:0`) means referenced nowhere — safe to delete; `internalUsage:true` means only the `export` keyword is redundant — deleting the symbol would break its own module, so just drop the `export`. `orphanFiles` lists files with exports but zero external importers, excluding package entrypoints. Aliased imports (`import { a as b }`) count as cross-file usage; whole-module imports (`import *`, `export *`, dynamic `import()`, `require()`) mark every export of that module as used. Usage is counted across ALL tsconfigs discovered in the project (the scanned set is returned as `scannedConfigs`/`scannedFileCount`), so an export consumed only by a sibling config (e.g. `scripts/` on `tsconfig.scripts.json`) is not falsely reported dead. The `ignore` glob suppresses files only as reported candidates — ignored files (e.g. tests) still count as usage sources, so a test-only export is not reported dead. Returns total export/file counts, `deadCount`, `internalOnlyCount`, `orphanFiles`, `scannedConfigs`, `scannedFileCount`, and the unused list. Read-only.",
+			"Find exports that no OTHER file in the project imports, plus exported files with no external usage. A per-export hit is a DE-EXPORT signal, not automatically a DELETE signal: each entry carries `internalUsage`/`internalRefCount` telling you whether the symbol is still referenced WITHIN its own file. `internalUsage:false` (`internalRefCount:0`) means referenced nowhere — safe to delete; `internalUsage:true` means only the `export` keyword is redundant — deleting the symbol would break its own module, so just drop the `export`. `orphanFiles` lists files with exports but zero external importers, excluding package entrypoints. Recognized App Router code entrypoints and caller-supplied entrypoint globs are omitted from unused/dead verdicts and reported in `excludedEntrypointFiles`, because static imports cannot observe framework dispatch. Aliased imports (`import { a as b }`) count as cross-file usage; whole-module imports (`import *`, `export *`, dynamic `import()`, `require()`) mark every export of that module as used. Usage is counted across ALL tsconfigs discovered in the project (the scanned set is returned as `scannedConfigs`/`scannedFileCount`), so an export consumed only by a sibling config (e.g. `scripts/` on `tsconfig.scripts.json`) is not falsely reported dead. The `ignore` glob suppresses files only as reported candidates — ignored files (e.g. tests) still count as usage sources, so a test-only export is not reported dead. Returns total export/file counts, `deadCount`, `internalOnlyCount`, `orphanFiles`, `excludedEntrypointFiles`, `scannedConfigs`, `scannedFileCount`, and the unused list. Read-only.",
 	},
 	{
 		name: "mock-cleanup",

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -183,7 +183,13 @@ export const COMMANDS: CommandDef[] = [
 	{
 		name: "analyze",
 		helpText: cliHelp("analyze"),
-		options: ["verbose", "project", "workspace", "only-related-to"],
+		options: [
+			"verbose",
+			"project",
+			"workspace",
+			"only-related-to",
+			"entrypoint-globs",
+		],
 		run: async ([file], values) => {
 			requireArg("analyze", "<file>", file);
 			await analyzeCommand({
@@ -192,6 +198,7 @@ export const COMMANDS: CommandDef[] = [
 				project: values.project,
 				workspace: values.workspace,
 				onlyRelatedTo: values["only-related-to"],
+				entrypointGlobs: values["entrypoint-globs"],
 			});
 		},
 	},

--- a/src/commands/unused.test.ts
+++ b/src/commands/unused.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import { createSourceFileFromText } from "../core/source-file.ts";
 import { CLI, cleanup, makeFixture as makeFixtureBase } from "./__test-helpers";
-import { countInternalReferences } from "./unused.ts";
+import { countInternalReferences, findUnusedExports } from "./unused.ts";
 
 async function makeFixture(name: string, files: Record<string, string>) {
 	return makeFixtureBase(`unused-${name}`, {
@@ -14,7 +14,92 @@ async function makeFixture(name: string, files: Record<string, string>) {
 	});
 }
 
+interface UnusedJsonReport {
+	excludedEntrypointFiles: string[];
+	excludedEntrypointFileCount: number;
+	unused: Array<{ file: string }>;
+	orphanFiles: Array<{ file: string }>;
+}
+
+async function runUnusedJson(directory: string): Promise<UnusedJsonReport> {
+	const proc = Bun.spawn([...CLI, "unused", directory, "--json"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	await proc.exited;
+	if (proc.exitCode !== 0) {
+		throw new Error(`unused command failed: ${stderr}`);
+	}
+	return JSON.parse(stdout) as UnusedJsonReport;
+}
+
 describe("unused command", () => {
+	test("excludes App Router entrypoints while retaining ordinary same-stem modules", async () => {
+		const dir = await makeFixtureBase("unused-framework-entrypoints", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true, jsx: "preserve" },
+				include: ["src/**/*.ts", "src/**/*.tsx"],
+			}),
+			"src/app/api/example/route.ts": [
+				"export async function GET() {}",
+				"export async function POST() {}",
+			].join("\n"),
+			"src/app/layout.tsx":
+				"export default function Layout() { return null; }\n",
+			"src/app/blog/page.tsx":
+				"export default function Page() { return null; }\n",
+			"src/app/blog/apple-icon.tsx": [
+				"export const size = { width: 32, height: 32 };",
+				"export default function AppleIcon() { return null; }",
+			].join("\n"),
+			"src/app/blog/opengraph-image.tsx": [
+				"export const contentType = 'image/png';",
+				"export default function OpenGraphImage() { return null; }",
+			].join("\n"),
+			"src/app/sitemap.ts":
+				"export default function sitemap() { return []; }\n",
+			"src/lib/route.ts": "export function GET() { return 'ordinary'; }\n",
+		});
+		try {
+			const report = await runUnusedJson(dir);
+			const libraryReport = await findUnusedExports(dir);
+			const relativeUnused = report.unused.map((item: { file: string }) =>
+				path.relative(dir, item.file)
+			);
+			const relativeOrphans = report.orphanFiles.map((item: { file: string }) =>
+				path.relative(dir, item.file)
+			);
+
+			expect(relativeUnused).toEqual([path.join("src", "lib", "route.ts")]);
+			expect(relativeOrphans).toEqual([path.join("src", "lib", "route.ts")]);
+
+			const relativeExcluded = report.excludedEntrypointFiles.map(
+				(file: string) => path.relative(dir, file)
+			);
+			expect(relativeExcluded).toEqual([
+				path.join("src", "app", "api", "example", "route.ts"),
+				path.join("src", "app", "blog", "apple-icon.tsx"),
+				path.join("src", "app", "blog", "opengraph-image.tsx"),
+				path.join("src", "app", "blog", "page.tsx"),
+				path.join("src", "app", "layout.tsx"),
+				path.join("src", "app", "sitemap.ts"),
+			]);
+			expect(report.excludedEntrypointFileCount).toBe(6);
+			expect(libraryReport.excludedEntrypointFiles).toEqual(
+				report.excludedEntrypointFiles
+			);
+			expect(libraryReport.unused.map((item) => item.file)).toEqual(
+				report.unused.map((item) => item.file)
+			);
+		} finally {
+			await cleanup(dir);
+		}
+	});
+
 	test("unused MCP tool returns orphan files", async () => {
 		const serverSource = await Bun.file(
 			path.resolve(import.meta.dir, "../mcp-server.ts")
@@ -40,6 +125,12 @@ describe("unused command", () => {
 		);
 		expect(serverSource).toContain(
 			"excludedGeneratedFiles: report.excludedGeneratedFiles.map"
+		);
+		expect(serverSource).toContain(
+			"excludedEntrypointFileCount: report.excludedEntrypointFileCount"
+		);
+		expect(serverSource).toContain(
+			"excludedEntrypointFiles: report.excludedEntrypointFiles.map"
 		);
 	});
 

--- a/src/commands/unused.test.ts
+++ b/src/commands/unused.test.ts
@@ -38,6 +38,7 @@ async function runUnusedJson(directory: string): Promise<UnusedJsonReport> {
 }
 
 describe("unused command", () => {
+	// @BDD: ANLY-003-Verified
 	test("excludes App Router entrypoints while retaining ordinary same-stem modules", async () => {
 		const dir = await makeFixtureBase("unused-framework-entrypoints", {
 			"tsconfig.json": JSON.stringify({
@@ -683,6 +684,7 @@ describe("unused command", () => {
 		await cleanup(dir);
 	});
 
+	// @BDD: ANLY-004-Verified
 	test("--entrypoint-globs excludes convention entrypoints from orphan files", async () => {
 		const dir = await makeFixture("entrypoint-globs", {
 			"hooks/dispatch.ts": "export function runHook() { return 1; }",

--- a/src/commands/unused.ts
+++ b/src/commands/unused.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import ts from "typescript";
 import { logger } from "../cli-logger.ts";
 import {
+	isConventionEntrypointFile,
+	normalizeEntrypointGlobs,
+} from "../core/framework-conventions.ts";
+import {
 	createFrameworkGeneratedArtifactClassifier,
 	excludeFrameworkGeneratedArtifacts,
 	generatedArtifactWarning,
@@ -40,34 +44,6 @@ export interface UnusedOptions extends ReadOnlyCommandOptions {
 	entrypointGlobs?: string | string[];
 }
 
-function normalizeGlobs(
-	globs: string | string[] | undefined
-): readonly string[] {
-	if (!globs) {
-		return [];
-	}
-	return Array.isArray(globs) ? globs : [globs];
-}
-
-function matchesAnyGlob(file: string, patterns: readonly string[]): boolean {
-	const basename = path.basename(file);
-	// Also build relative-path suffixes so a pattern like "hooks/**" matches
-	// absolute paths like "/project/hooks/dispatch.ts".
-	const segments = file.split(path.sep).filter(Boolean);
-	for (const pattern of patterns) {
-		const glob = new Bun.Glob(pattern);
-		if (glob.match(file) || glob.match(basename)) {
-			return true;
-		}
-		for (let i = 0; i < segments.length - 1; i++) {
-			if (glob.match(segments.slice(i).join(path.sep))) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
 export interface UnusedExport {
 	file: string;
 	name: string;
@@ -103,6 +79,9 @@ export interface UnusedReport {
 	warnings: string[];
 	excludedGeneratedFiles: string[];
 	excludedGeneratedFileCount: number;
+	/** Built-in or configured entrypoint files omitted from unused/dead verdicts. */
+	excludedEntrypointFiles: string[];
+	excludedEntrypointFileCount: number;
 	unused: UnusedExport[];
 	orphanFiles: OrphanFile[];
 	totalExports: number;
@@ -153,6 +132,8 @@ export async function findUnusedExports(
 			warnings: [],
 			excludedGeneratedFiles: [],
 			excludedGeneratedFileCount: 0,
+			excludedEntrypointFiles: [],
+			excludedEntrypointFileCount: 0,
 			unused: [],
 			orphanFiles: [],
 			totalExports: 0,
@@ -224,6 +205,8 @@ export async function findUnusedExportsFromGraphs(
 			warnings: [],
 			excludedGeneratedFiles: [],
 			excludedGeneratedFileCount: 0,
+			excludedEntrypointFiles: [],
+			excludedEntrypointFileCount: 0,
 			unused: [],
 			orphanFiles: [],
 			totalExports: 0,
@@ -265,11 +248,14 @@ export async function findUnusedExportsFromGraphs(
 	// CANDIDATES only — ignored files (e.g. tests) still contribute to the usage
 	// graph above, so a test-only export is not falsely reported dead.
 	const ignorePattern = options?.ignore ? new Bun.Glob(options.ignore) : null;
-	const entrypointGlobPatterns = normalizeGlobs(options?.entrypointGlobs);
+	const entrypointGlobPatterns = normalizeEntrypointGlobs(
+		options?.entrypointGlobs
+	);
 
 	const unused: UnusedExport[] = [];
 	const exportedFiles = new Map<string, ExportInfo[]>();
 	const entrypointFiles = await collectPackageEntrypointFiles(absoluteDir);
+	const excludedEntrypointFiles = new Set<string>();
 	const skippedFiles = new Set(graph.skippedFiles);
 	let totalExports = 0;
 
@@ -280,10 +266,8 @@ export async function findUnusedExportsFromGraphs(
 		) {
 			continue;
 		}
-		if (
-			entrypointGlobPatterns.length > 0 &&
-			matchesAnyGlob(file, entrypointGlobPatterns)
-		) {
+		if (isConventionEntrypointFile(file, entrypointGlobPatterns)) {
+			excludedEntrypointFiles.add(normalizePath(file));
 			continue;
 		}
 
@@ -363,6 +347,8 @@ export async function findUnusedExportsFromGraphs(
 				: [],
 		excludedGeneratedFiles: [...excludedGeneratedFiles].sort(),
 		excludedGeneratedFileCount: excludedGeneratedFiles.size,
+		excludedEntrypointFiles: [...excludedEntrypointFiles].sort(),
+		excludedEntrypointFileCount: excludedEntrypointFiles.size,
 		unused,
 		orphanFiles,
 		totalExports,
@@ -414,7 +400,7 @@ export function computeOrphanFiles(
 		if (exports.length === 0 || entrypointFiles.has(normalizePath(file))) {
 			continue;
 		}
-		if (entrypointGlobs.length > 0 && matchesAnyGlob(file, entrypointGlobs)) {
+		if (isConventionEntrypointFile(file, entrypointGlobs)) {
 			continue;
 		}
 
@@ -908,6 +894,18 @@ export async function unusedCommand(options: UnusedOptions): Promise<void> {
 	logger.info(
 		`📊 Scanned ${report.totalExports} export(s) across ${report.totalFiles} file(s)\n`
 	);
+
+	if (report.excludedEntrypointFileCount > 0) {
+		logger.info(
+			`↪ Excluded ${report.excludedEntrypointFileCount} framework or configured entrypoint file(s) from unused/dead verdicts.`
+		);
+		if (verbose) {
+			for (const file of report.excludedEntrypointFiles) {
+				logger.info(`   ${path.relative(absoluteDir, file)}`);
+			}
+		}
+		logger.empty();
+	}
 
 	if (report.excludedGeneratedFileCount > 0) {
 		logger.warn(

--- a/src/core/framework-conventions.test.ts
+++ b/src/core/framework-conventions.test.ts
@@ -22,9 +22,12 @@ const ROUTE_SEGMENT_CONVENTION_STEMS = [
 ] as const;
 
 const APP_ROOT_CONVENTION_STEMS = [
+	"forbidden",
 	"global-error",
+	"global-not-found",
 	"manifest",
 	"robots",
+	"unauthorized",
 ] as const;
 
 describe("framework conventions", () => {

--- a/src/core/framework-conventions.ts
+++ b/src/core/framework-conventions.ts
@@ -14,7 +14,9 @@ const NEXT_APP_ROUTER_CONVENTIONS = new Map<string, AppRouterConventionScope>([
 	["apple-icon", "route-segment"],
 	["default", "route-segment"],
 	["error", "route-segment"],
+	["forbidden", "app-root"],
 	["global-error", "app-root"],
+	["global-not-found", "app-root"],
 	["icon", "route-segment"],
 	["layout", "route-segment"],
 	["loading", "route-segment"],
@@ -27,7 +29,10 @@ const NEXT_APP_ROUTER_CONVENTIONS = new Map<string, AppRouterConventionScope>([
 	["sitemap", "route-segment"],
 	["template", "route-segment"],
 	["twitter-image", "route-segment"],
+	["unauthorized", "app-root"],
 ]);
+
+export type EntrypointGlobs = string | readonly string[];
 
 /**
  * Monorepo directories that hold packages rather than route segments; an `app`
@@ -128,4 +133,52 @@ export function isFrameworkConventionFile(
 	}
 
 	return scope === "route-segment" || appRootIndex === segments.length - 2;
+}
+
+export function normalizeEntrypointGlobs(
+	globs: EntrypointGlobs | undefined
+): readonly string[] {
+	if (!globs) {
+		return [];
+	}
+	return typeof globs === "string" ? [globs] : globs;
+}
+
+/**
+ * Match an absolute or relative file path against caller-configured entrypoint
+ * globs. Relative suffix matching keeps patterns such as `hooks/**` useful when
+ * command internals operate on absolute project paths.
+ */
+export function matchesEntrypointGlob(
+	filePath: string,
+	globs: EntrypointGlobs | undefined
+): boolean {
+	const basename = path.basename(filePath);
+	const segments = filePath.split(path.sep).filter(Boolean);
+	for (const pattern of normalizeEntrypointGlobs(globs)) {
+		const glob = new Bun.Glob(pattern);
+		if (glob.match(filePath) || glob.match(basename)) {
+			return true;
+		}
+		for (let index = 0; index < segments.length - 1; index++) {
+			if (glob.match(segments.slice(index).join(path.sep))) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * True when a file is consumed externally either by a built-in framework
+ * filename contract or by an explicit caller-supplied entrypoint glob.
+ */
+export function isConventionEntrypointFile(
+	filePath: string,
+	globs?: EntrypointGlobs
+): boolean {
+	return (
+		isFrameworkConventionFile(filePath) ||
+		matchesEntrypointGlob(filePath, globs)
+	);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ export type {
 } from "./commands/alias.ts";
 export { aliasCommand, planAliasEdits } from "./commands/alias.ts";
 // ── Commands: analyze ───────────────────────────────────────────────
-export type { AnalyzeOptions } from "./commands/analyze.ts";
+export type {
+	AnalyzeFileOptions,
+	AnalyzeOptions,
+} from "./commands/analyze.ts";
 export { analyze, analyzeCommand } from "./commands/analyze.ts";
 // ── Commands: analyze-impact ────────────────────────────────────────
 export type { AnalyzeImpactOptions } from "./commands/analyze-impact.ts";

--- a/src/mcp-entrypoints.test.ts
+++ b/src/mcp-entrypoints.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { cleanup, makeFixture } from "./commands/__test-helpers.ts";
+import { analyzeTool, unusedTool } from "./mcp-server.ts";
+
+interface AnalyzeEntrypointPayload {
+	externalUsageAssumed: boolean;
+	noExternalUsage: boolean;
+	unusedExports: Array<{ name: string }>;
+}
+
+interface UnusedEntrypointPayload {
+	excludedEntrypointFileCount: number;
+	excludedEntrypointFiles: string[];
+	unused: Array<{ file: string; name: string }>;
+	orphanFiles: Array<{ file: string }>;
+}
+
+function parsePayload<T>(result: CallToolResult): T {
+	const content = result.content[0];
+	if (content?.type !== "text") {
+		throw new Error("Expected an MCP text result");
+	}
+	return JSON.parse(content.text) as T;
+}
+
+describe("MCP framework and configured entrypoints", () => {
+	test("agrees with library and CLI verdicts for assumed external usage", async () => {
+		const dir = await makeFixture("mcp-entrypoints", {
+			"tsconfig.json": JSON.stringify({
+				compilerOptions: { strict: true },
+				include: ["src/**/*.ts"],
+			}),
+			"src/app/api/example/route.ts": "export async function GET() {}\n",
+			"src/hooks/dispatch.ts": "export function runHook() {}\n",
+			"src/lib/route.ts": "export function GET() { return 'ordinary'; }\n",
+		});
+		try {
+			const project = path.join(dir, "tsconfig.json");
+			const routeFile = path.join(dir, "src/app/api/example/route.ts");
+			const hookFile = path.join(dir, "src/hooks/dispatch.ts");
+			const ordinaryFile = path.join(dir, "src/lib/route.ts");
+
+			const route = parsePayload<AnalyzeEntrypointPayload>(
+				await analyzeTool(routeFile, { project })
+			);
+			expect(route.externalUsageAssumed).toBeTrue();
+			expect(route.noExternalUsage).toBeFalse();
+			expect(route.unusedExports).toHaveLength(0);
+
+			const configured = parsePayload<AnalyzeEntrypointPayload>(
+				await analyzeTool(hookFile, {
+					project,
+					entrypointGlobs: "src/hooks/**",
+				})
+			);
+			expect(configured.externalUsageAssumed).toBeTrue();
+			expect(configured.unusedExports).toHaveLength(0);
+
+			const ordinary = parsePayload<AnalyzeEntrypointPayload>(
+				await analyzeTool(ordinaryFile, { project })
+			);
+			expect(ordinary.externalUsageAssumed).toBeFalse();
+			expect(ordinary.noExternalUsage).toBeTrue();
+			expect(ordinary.unusedExports.map((item) => item.name)).toEqual(["GET"]);
+
+			const unused = parsePayload<UnusedEntrypointPayload>(
+				await unusedTool(dir, { project })
+			);
+			expect(unused.excludedEntrypointFileCount).toBe(1);
+			expect(unused.excludedEntrypointFiles).toEqual([
+				path.join("src", "app", "api", "example", "route.ts"),
+			]);
+			expect(unused.unused).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						file: path.join("src", "hooks", "dispatch.ts"),
+						name: "runHook",
+					}),
+					expect.objectContaining({
+						file: path.join("src", "lib", "route.ts"),
+						name: "GET",
+					}),
+				])
+			);
+			expect(unused.orphanFiles.map((item) => item.file)).toEqual([
+				path.join("src", "hooks", "dispatch.ts"),
+				path.join("src", "lib", "route.ts"),
+			]);
+		} finally {
+			await cleanup(dir);
+		}
+	});
+});

--- a/src/mcp-entrypoints.test.ts
+++ b/src/mcp-entrypoints.test.ts
@@ -26,6 +26,8 @@ function parsePayload<T>(result: CallToolResult): T {
 }
 
 describe("MCP framework and configured entrypoints", () => {
+	// @BDD: ANLY-003-Verified
+	// @BDD: ANLY-004-Verified
 	test("agrees with library and CLI verdicts for assumed external usage", async () => {
 		const dir = await makeFixture("mcp-entrypoints", {
 			"tsconfig.json": JSON.stringify({

--- a/src/mcp-schema-parity.test.ts
+++ b/src/mcp-schema-parity.test.ts
@@ -133,6 +133,7 @@ const EXPECTED: Record<string, string[]> = {
 		"ignore",
 		"entrypointGlobs", // #129
 	],
+	analyze: ["file", "project", "entrypointGlobs"],
 	naming: [
 		"directory",
 		"project",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -214,17 +214,25 @@ function findTool(
 	});
 }
 
-async function analyzeTool(
+export async function analyzeTool(
 	file: string,
-	project?: string
+	options: {
+		project?: string;
+		entrypointGlobs?: string | string[];
+	} = {}
 ): Promise<CallToolResult> {
 	const absolutePath = path.resolve(file);
-	const tsconfigPath = resolveTsConfig(project, path.dirname(absolutePath));
+	const tsconfigPath = resolveTsConfig(
+		options.project,
+		path.dirname(absolutePath)
+	);
 	if (!tsconfigPath) {
 		return tsconfigNotFound(absolutePath);
 	}
 	const projectConfig = loadProject(tsconfigPath, absolutePath);
-	const result = await analyze(absolutePath, projectConfig);
+	const result = await analyze(absolutePath, projectConfig, {
+		entrypointGlobs: options.entrypointGlobs,
+	});
 	const root = projectConfig.rootDir;
 	return jsonText({
 		file: path.relative(root, result.file),
@@ -264,6 +272,7 @@ async function analyzeTool(
 			internalRefCount: e.internalRefCount,
 		})),
 		noExternalUsage: result.noExternalUsage,
+		externalUsageAssumed: result.externalUsageAssumed,
 		skippedFileCount: result.skippedFiles.length,
 		skippedFiles: result.skippedFiles.map((file) => path.relative(root, file)),
 		coverageIncomplete: result.skippedFiles.length > 0,
@@ -455,7 +464,7 @@ async function barrelTool(
 	return jsonText(barrelReportToJson(report, baseDir));
 }
 
-async function unusedTool(
+export async function unusedTool(
 	directory: string,
 	options: {
 		project?: string;
@@ -498,6 +507,10 @@ async function unusedTool(
 		warnings: report.warnings,
 		excludedGeneratedFileCount: report.excludedGeneratedFileCount,
 		excludedGeneratedFiles: report.excludedGeneratedFiles.map((file) =>
+			path.relative(absoluteDir, file)
+		),
+		excludedEntrypointFileCount: report.excludedEntrypointFileCount,
+		excludedEntrypointFiles: report.excludedEntrypointFiles.map((file) =>
 			path.relative(absoluteDir, file)
 		),
 		orphanFiles: report.orphanFiles.map((orphan) => ({
@@ -883,11 +896,17 @@ server.registerTool(
 				.describe(
 					"Optional path to the project root or tsconfig.json. Omit to auto-resolve the nearest tsconfig that owns the file (recommended)"
 				),
+			entrypointGlobs: z
+				.union([z.string(), z.array(z.string())])
+				.optional()
+				.describe(
+					"Optional glob pattern(s) for filename-dispatched entrypoints whose exports should be treated as externally consumed"
+				),
 		},
 	},
-	async ({ file, project }) => {
+	async ({ file, project, entrypointGlobs }) => {
 		return withErrorHandling(async () => {
-			return analyzeTool(file, project);
+			return analyzeTool(file, { project, entrypointGlobs });
 		});
 	}
 );

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -13,6 +13,8 @@ export interface AnalysisResult {
 	}>;
 	unusedExports: UnusedExportInfo[];
 	noExternalUsage: boolean;
+	/** True when framework/configuration dispatch makes static imports incomplete. */
+	externalUsageAssumed: boolean;
 	/** Project files omitted from graph-backed verdicts because they could not be parsed. */
 	skippedFiles: string[];
 }


### PR DESCRIPTION
## Summary
- treat valid Next.js App Router code entrypoints as externally consumed in analyze and unused results
- support repeatable custom entrypoint globs across CLI, MCP, and library surfaces
- expose structured assumption and exclusion evidence, document the static-import boundary, and capture ANLY-003/ANLY-004 requirements

## Why
Frameworks and manifests can dispatch files without a static import. Those files must not receive unused-export, orphan-file, or delete advice merely because the TypeScript import graph has no consumer.

## Testing
- focused entrypoint suite: 73 passed, 0 failed, 344 assertions across 5 files
- full Bun suite: 947 passed, 0 failed, 2727 assertions across 71 files
- pnpm run check
- pnpm run lint
- pnpm run typecheck
- pnpm run build:lib
- pnpm run verify:size
- canonical BDD validator: 44 valid scenarios, 0 errors; documented V1/P1 review warning
- guarded commit hooks rebuilt both binaries, ran the strict similarity scan, and refreshed the supported global install

## Risk / rollout
Low-to-moderate and limited to read-only classification. Built-in conventions are location-aware, configured globs are opt-in, and ordinary same-stem modules remain analyzable.

## Review scope
The diff is larger than the advisory review prompt because implementation, all three public surfaces, functional parity tests, documentation, and canonical requirements evidence form one atomic safety contract.

Closes #150