### PR TITLE
fix(cli): handle closed stdout pipes

### DIFF
--- a/.requirements-status.json
+++ b/.requirements-status.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "projectId": "mherod/resect",
   "requirementsFile": "REQUIREMENTS.md",
-  "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
-  "sourceCommit": "5cefe8c6a1c65f4fa42e56ea11404d38a338d7e8",
-  "generatedAt": "2026-08-08T06:17:46Z",
+  "requirementsSha256": "4749e2d78169354594d7ff6d4086f6b80737319a24f95fd2877d566688b5c2c4",
+  "sourceCommit": "c8818b789d57833411fbc8087dbb873923277a69",
+  "generatedAt": "2026-08-08T06:41:48Z",
   "validator": {
     "name": "generate-requirements",
     "version": "2.0.0",
@@ -13,15 +13,15 @@
   "validation": {
     "structure": {
       "status": "PASS",
-      "receiptId": "STRUCT-20260808-004",
+      "receiptId": "STRUCT-20260808-005",
       "validator": "validate-bdd",
       "validatorVersion": "2.0.0",
       "command": "bun scripts/validate-bdd.js /Users/matthew.herod/Development/resect/REQUIREMENTS.md --status-log /Users/matthew.herod/Development/resect/.requirements-status.json",
-      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
-      "sourceCommit": "5cefe8c6a1c65f4fa42e56ea11404d38a338d7e8",
-      "generatedAt": "2026-08-08T06:17:46Z",
+      "requirementsSha256": "4749e2d78169354594d7ff6d4086f6b80737319a24f95fd2877d566688b5c2c4",
+      "sourceCommit": "c8818b789d57833411fbc8087dbb873923277a69",
+      "generatedAt": "2026-08-08T06:41:48Z",
       "counts": {
-        "checked": 44,
+        "checked": 46,
         "errors": 0,
         "warnings": 0
       },
@@ -31,42 +31,43 @@
     },
     "documentQuality": {
       "status": "PASS",
-      "receiptId": "QUALITY-20260808-004",
+      "receiptId": "QUALITY-20260808-005",
       "validator": "generate-requirements-manual-review",
       "validatorVersion": "2.0.0",
       "command": "generate-requirements 2.0 manual review of REQUIREMENTS.md",
-      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
-      "sourceCommit": "5cefe8c6a1c65f4fa42e56ea11404d38a338d7e8",
-      "generatedAt": "2026-08-08T06:17:46Z",
+      "requirementsSha256": "4749e2d78169354594d7ff6d4086f6b80737319a24f95fd2877d566688b5c2c4",
+      "sourceCommit": "c8818b789d57833411fbc8087dbb873923277a69",
+      "generatedAt": "2026-08-08T06:41:48Z",
       "counts": {
-        "checked": 44,
+        "checked": 46,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "Reviewed all 44 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
+        "Reviewed all 46 scenarios for product-first wording, one-trigger atomicity, actor and limitation coverage, lifecycle mapping, cross-cutting applicability, and decision completeness.",
         "Framework-dispatched entrypoint safety is explicit across built-in valid App Router locations, ordinary same-stem controls, caller-configured globs, human-readable advice, and structured CLI, MCP, and library results.",
-        "Reviewed the V1/P1 priority concentration: the 27 source-backed P1 scenarios represent important non-critical safety and parity behavior, while the four launch-critical scenarios remain P0; retain the independently grounded priorities."
+        "CLI stream lifecycle behavior separates the expected closed-stdout alternative exit from unexpected stdout and stderr failures, while remaining outside MCP and library surfaces.",
+        "Reviewed the V1/P1 priority concentration: the 29 source-backed P1 scenarios represent important non-critical safety, reliability, and parity behavior, while the four launch-critical scenarios remain P0; retain the independently grounded priorities."
       ]
     },
     "implementation": {
       "status": "PASS",
-      "receiptId": "IMPL-20260808-004",
+      "receiptId": "IMPL-20260808-005",
       "validator": "bun-test-plus-clause-audit",
       "validatorVersion": "1.3.14+generate-requirements-2.0.0",
-      "command": "bun test --timeout=20000 src/core/framework-conventions.test.ts src/commands/analyze.test.ts src/commands/unused.test.ts src/mcp-entrypoints.test.ts src/mcp-schema-parity.test.ts --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
-      "requirementsSha256": "3a9a164c6f508c5544b9851d2a317c13cc742380f2b0c9ee45a3d8255b9ad8fc",
-      "sourceCommit": "5cefe8c6a1c65f4fa42e56ea11404d38a338d7e8",
-      "generatedAt": "2026-08-08T06:17:46Z",
+      "command": "bun test src/cli-stream-errors.test.ts src/cli.test.ts --timeout=20000 --parallel=4 && bun test --timeout=20000 --parallel=4 && pnpm run check && pnpm run lint && pnpm run typecheck && pnpm run build:lib && pnpm run verify:size",
+      "requirementsSha256": "4749e2d78169354594d7ff6d4086f6b80737319a24f95fd2877d566688b5c2c4",
+      "sourceCommit": "c8818b789d57833411fbc8087dbb873923277a69",
+      "generatedAt": "2026-08-08T06:41:48Z",
       "counts": {
-        "checked": 44,
+        "checked": 46,
         "errors": 0,
         "warnings": 0
       },
       "notes": [
-        "The framework convention, analyze, unused, and MCP focus passed 73 tests with 0 failures and 344 assertions across 5 files.",
-        "The complete Bun suite passed 947 tests with 0 failures across 71 files using the hook-required four-way parallelism; the guarded implementation commit additionally passed 716 affected tests with 0 failures and 2347 assertions across 57 files.",
-        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, the supported global install, and the configured tarball-size preflight passed; PR #200 CI run 31243361689 revalidated typecheck, lint, the full suite, and package size at source commit 5cefe8c.",
+        "The CLI stream focus passed 13 tests with 0 failures and 32 assertions across 2 files, including human-readable and JSON closed-pipe subprocesses plus unexpected stdout and stderr failures.",
+        "The complete Bun suite passed 954 tests with 0 failures across 72 files using the hook-required four-way parallelism.",
+        "Biome checks, ESLint, TypeScript, the library build, the compiled binary hook build, the strict 0.95 similarity scan, the supported global install, and the configured tarball-size preflight passed at source commit c8818b7.",
         "MOVE-001 through MOVE-003 map to src/commands/move.test.ts and src/commands/move.ts at source commit 52106e7.",
         "TIDY-001, TIDY-002, and ROLL-001 map to src/commands/tidy.test.ts, src/core/rollback.test.ts, src/commands/tidy.ts, and src/core/rollback.ts at source commit 52106e7.",
         "CFG-001 through CFG-006 map to src/core/project-config.test.ts, src/commands/config-defaults.test.ts, src/commands/discover.test.ts, and their corresponding implementation files at source commit 52106e7.",
@@ -80,32 +81,33 @@
         "UNDO-001 through UNDO-005 map to src/core/journal.ts, src/core/journal.test.ts, src/commands/undo.ts, src/commands/undo.test.ts, src/commands/journal-integration.test.ts, src/commands/registry.ts, src/mcp-server.ts, and src/index.ts.",
         "ANLY-001 and ANLY-002 map to src/core/generated-artifacts.ts, src/core/generated-artifacts.test.ts, src/commands/audit.test.ts, src/commands/naming.test.ts, src/commands/unused.test.ts, src/mcp-server.ts, and src/types/naming.ts at source commit dc4c1d4.",
         "ANLY-003 and ANLY-004 map to src/core/framework-conventions.ts, src/core/framework-conventions.test.ts, src/commands/analyze.test.ts, src/commands/unused.test.ts, src/mcp-entrypoints.test.ts, src/mcp-schema-parity.test.ts, src/mcp-server.ts, and src/index.ts at source commit 5cefe8c.",
-        "BARL-001 and BARL-002 map to src/core/framework-conventions.ts, src/commands/barrel.ts, src/commands/barrel.test.ts, src/mcp-server.ts, and src/index.test.ts at source commit dc4c1d4."
+        "BARL-001 and BARL-002 map to src/core/framework-conventions.ts, src/commands/barrel.ts, src/commands/barrel.test.ts, src/mcp-server.ts, and src/index.test.ts at source commit dc4c1d4.",
+        "CLI-001 and CLI-002 map to src/cli-stream-errors.ts, src/cli-stream-errors.test.ts, src/cli.ts, and src/cli.test.ts at source commit c8818b7."
       ]
     }
   },
   "metrics": {
-    "totalScenarios": 44,
+    "totalScenarios": 46,
     "byDelivery": {
-      "V1": 44,
+      "V1": 46,
       "V2": 0,
       "LATER": 0,
       "UNSLICED": 0
     },
     "byDecision": {
-      "DECIDED": 44,
+      "DECIDED": 46,
       "OPEN": 0
     },
     "byPriority": {
       "P0": 4,
-      "P1": 27,
+      "P1": 29,
       "P2": 13,
       "P3": 0
     },
     "priorityByDelivery": {
       "V1": {
         "P0": 4,
-        "P1": 27,
+        "P1": 29,
         "P2": 13,
         "P3": 0
       },
@@ -129,15 +131,15 @@
       }
     },
     "byFidelity": {
-      "VERIFIED": 44,
+      "VERIFIED": 46,
       "DRIFTED": 0,
       "MISSING": 0,
       "UNTESTABLE": 0
     },
     "coverage": {
       "v1Decided": {
-        "eligible": 44,
-        "verified": 44,
+        "eligible": 46,
+        "verified": 46,
         "percentage": 100
       },
       "v1LaunchCritical": {
@@ -179,8 +181,8 @@
     "fidelityNoteMismatchIds": [],
     "orphanAnchorIds": [],
     "preamble": {
-      "linesBeforeFirstScenario": 107,
-      "percentageBeforeFirstScenario": 20.7,
+      "linesBeforeFirstScenario": 108,
+      "percentageBeforeFirstScenario": 20.0,
       "warning": false,
       "disposition": null
     },
@@ -188,9 +190,9 @@
       {
         "delivery": "V1",
         "tier": "P1",
-        "percentage": 61.4,
+        "percentage": 63.0,
         "warning": true,
-        "disposition": "Retain the independently grounded priorities: the 27 P1 scenarios are important non-critical safety and parity behavior, while the four launch-critical scenarios remain P0."
+        "disposition": "Retain the independently grounded priorities: the 29 P1 scenarios are important non-critical safety, reliability, and parity behavior, while the four launch-critical scenarios remain P0."
       }
     ]
   },

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -9,7 +9,7 @@
 
 ## Product Ground Truth
 
-Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, framework-aware naming safety, source-focused read-only analysis, framework-dispatched entrypoint safety, and framework-aware barrel findings. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
+Resect is a local TypeScript and JavaScript refactoring tool exposed through a CLI, an MCP server, and a programmatic API. This baseline covers safe move failures, truthful tidy rollback, reusable rollback behavior, opt-in operation journaling and user-initiated undo, project-wide defaults, transform configuration trust and import preference, shared-context batch moves, explicit filename-casing enforcement, framework-aware naming safety, source-focused read-only analysis, framework-dispatched entrypoint safety, framework-aware barrel findings, and quiet CLI termination when a downstream stdout consumer closes normally. Other behaviours remain outside this baseline until they receive source-backed scenarios. The host operating system controls filesystem and process access; resect adds validation, dirty-worktree protection, dry-run previews, pre-execution trust warnings, bounded local operation history, and verification boundaries but has no account, tenant, or remote session model.
 
 ## Source Register
 
@@ -30,14 +30,15 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | SRC-013 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/189 | Framework metadata entrypoint treatment in barrel inventory and unused findings |
 | SRC-014 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/179 | No-op and framework-convention filename safety across naming reports and fixes |
 | SRC-015 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/150 | Framework convention entrypoint treatment in analyze and unused results |
+| SRC-016 | Repository owner issue | 2026-08-08 | https://github.com/mherod/resect/issues/192 | Expected closed-stdout termination and unexpected stream-error visibility |
 
 ## Delivery and Decision Register
 
 | Decision ID | Decision | State | Delivery | Sources | Reversal condition |
 |---|---|---|---|---|---|
-| DR-001 | This baseline covers the fourteen accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013, SRC-014, SRC-015 | A repository-owner decision expands or retires the baseline. |
+| DR-001 | This baseline covers the fifteen accepted issue scopes registered above. | DECIDED | V1 | SRC-001, SRC-002, SRC-003, SRC-004, SRC-005, SRC-006, SRC-008, SRC-009, SRC-010, SRC-011, SRC-012, SRC-013, SRC-014, SRC-015, SRC-016 | A repository-owner decision expands or retires the baseline. |
 | DR-002 | Resect is a local developer tool without accounts, tenants, sessions, notifications, analytics, or media. | DECIDED | V1 | SRC-007 | A published contract adds one of these product surfaces. |
-| DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009 | The execution model moves into a managed remote sandbox. |
+| DR-003 | Filesystem and process permissions remain host concerns; resect must expose executable-config trust boundaries, report failures, and protect the workspace it mutates. | DECIDED | V1 | SRC-001, SRC-002, SRC-006, SRC-007, SRC-009, SRC-016 | The execution model moves into a managed remote sandbox. |
 | DR-004 | Batch moves are sequential within one process and use one setup, worktree guard, and verification boundary. | DECIDED | V1 | SRC-006 | A repository-owner decision introduces parallel or cross-process coordination. |
 | DR-005 | Explicit invocation values override command defaults, which override global defaults, which override built-in behavior. | DECIDED | V1 | SRC-004, SRC-007 | A published configuration contract changes precedence. |
 | DR-006 | Operation journaling is explicit, local to the project, capped at 20 retained entries, and intended to reverse one recorded operation rather than provide a transaction log; later work blocks undo unless the consumer explicitly forces it. | DECIDED | V1 | SRC-011 | A repository-owner decision introduces transactional history, another retention limit, or automatic journaling. |
@@ -46,7 +47,7 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 
 | Actor | Access scope and capabilities | Limitation and direct-attempt coverage | Passive perspective |
 |---|---|---|---|
-| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, unsafe undo attempts, no-op or framework-reserved naming moves, and false delete advice for convention entrypoints are refused or excluded; MOVE-002, CFG-004, BATCH-005, UNDO-004, NAM-005, ANLY-003. | Resolved configuration, previews, journal identifiers, location-aware target-casing findings, source-focused metrics, generated-artifact exclusions, framework entrypoint assumptions, and framework-aware barrel findings are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002. |
+| Operator | Invokes the CLI against a local project under host filesystem permissions. | Fatal writes, invalid config, malformed manifests, unprotected dirty mutations, unsafe undo attempts, no-op or framework-reserved naming moves, false delete advice for convention entrypoints, and unexpected stream failures are refused, excluded, or reported; MOVE-002, CFG-004, BATCH-005, UNDO-004, NAM-005, ANLY-003, CLI-002. | Resolved configuration, previews, journal identifiers, location-aware target-casing findings, source-focused metrics, generated-artifact exclusions, framework entrypoint assumptions, framework-aware barrel findings, and quiet expected closed-pipe exits are observable; CFG-005, BATCH-001, JOUR-001, UNDO-003, NAM-001, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002, CLI-001. |
 | API Consumer | Invokes MCP or library operations against an explicitly supplied project and receives structured results. | Invalid or empty batch input and unsafe undo attempts are rejected before mutation; BATCH-007, UNDO-004. | MCP mutations and undo default to dry-run, while journal entries, location-aware target-casing findings, audit exclusions, generated-artifact exclusions, framework entrypoint assumptions and exclusions, and framework-aware barrel findings are structured; JOUR-001, UNDO-003, BATCH-006, NAM-001, NAM-004, AUDIT-004, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002. |
 
 ## Actor Groups
@@ -72,8 +73,8 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Entry | JOUR-001, CFG-001, TRNS-003, BATCH-001, BATCH-006, NAM-001, ANLY-003, ANLY-004, BARL-001 | Journal, configuration, transform, batch, target-casing, source-analysis, and barrel-analysis entry points are explicit. |
 | Passive observation | JOUR-001, UNDO-003, CFG-005, TRNS-003, BATCH-001, BATCH-006, NAM-001, NAM-003, NAM-004, AUDIT-001, AUDIT-002, AUDIT-003, AUDIT-004, ANLY-001, ANLY-002, ANLY-003, ANLY-004, BARL-001, BARL-002 | Operators and API consumers receive journal identifiers, resolved values, warnings, previews, or analysis output. |
 | Successful exit | UNDO-001, UNDO-002, MOVE-001, BATCH-002, NAM-002, NAM-005 | Successful mutations and reversals report the applied operation while excluded naming moves remain untouched. |
-| Cancel or alternative exit | UNDO-003, BATCH-001 | Dry-run is the non-mutating alternative. |
-| Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007 | Failure paths preserve truthful outcomes. |
+| Cancel or alternative exit | UNDO-003, BATCH-001, CLI-001 | Dry-run is the non-mutating alternative, and a downstream consumer may end a successful pipeline after receiving its requested prefix. |
+| Failure or timeout | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, BATCH-004, BATCH-005, BATCH-007, CLI-002 | Failure paths preserve truthful outcomes. |
 | Interruption and re-entry | JOUR-001, UNDO-001, TIDY-002, ROLL-001 | Journal state survives command boundaries, and interrupted verification restores the checkpoint when enabled. |
 | Illegal transitions | UNDO-004, UNDO-005, CFG-004, BATCH-005, BATCH-007 | Invalid inputs and unsafe or unavailable reversals fail before mutation. |
 | LIFE-NA-001 — System-driven transitions | N/A — commands run only on caller invocation | Decision: DR-002 |
@@ -96,7 +97,7 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 | Search and discovery | APPLIES | CFG-001, CFG-005, NAM-004, AUDIT-001, ANLY-001, ANLY-003, ANLY-004, BARL-001 | Project configuration and configured source, output, or framework-convention boundaries are discovered and applied. |
 | Empty and first-run states | APPLIES | UNDO-005, CFG-006, BATCH-005, BATCH-007 | Missing undo history and config are handled explicitly, and empty batches are rejected. |
 | Limits, quotas, and upgrade or denial behavior | APPLIES | JOUR-002 | Local operation history has a fixed retention limit without a plan or upgrade model; DR-006. |
-| Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004 | Mutating and reversal failures report truthfully and preserve later work unless explicitly forced. |
+| Errors, degraded states, retry, and recovery | APPLIES | UNDO-004, UNDO-005, MOVE-002, TIDY-001, TIDY-002, ROLL-001, BATCH-004, CLI-001, CLI-002 | Mutating and reversal failures report truthfully, while the CLI distinguishes an expected closed stdout pipe from unexpected stream failures. |
 | Persistence, interruption, and re-entry | APPLIES | JOUR-001, UNDO-001, UNDO-002, TIDY-002, ROLL-001 | Journal entries persist across command invocations and support a later guarded reversal. |
 | Data lifecycle, retention, deletion, and export | APPLIES | JOUR-002 | Operation history retains only the newest 20 entries; SRC-011, DR-006. |
 | Analytics and telemetry | N/A | — | No analytics or telemetry surface in baseline; DR-002; XC-NA-008. |
@@ -506,12 +507,32 @@ Resect is a local TypeScript and JavaScript refactoring tool exposed through a C
 **When** an Analysis Consumer runs barrel analysis through a supported CLI, MCP, or library surface
 **Then** the framework metadata entrypoint remains in the general barrel inventory
 
+## Feature: CLI Stream Lifecycle
+
+### CLI-001 — Operator — End an intentionally shortened stdout pipeline quietly
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-016
+
+**Given** an Operator runs a human-readable or JSON CLI command through a downstream consumer that needs only an output prefix
+**When** the downstream consumer closes stdout after receiving that prefix
+**Then** the resect process exits successfully
+**And** no broken-pipe diagnostic is written to stderr
+
+### CLI-002 — Operator — Preserve unexpected stream failures
+
+**Delivery:** V1 | **Decision:** DECIDED | **Priority:** P1 | **Fidelity:** VERIFIED | **Sources:** SRC-016
+
+**Given** an Operator invokes a CLI command whose stdout or stderr stream encounters an unexpected error
+**When** the stream error occurs
+**Then** the resect process exits unsuccessfully
+**And** the stream diagnostic remains visible
+
 ## Validation Receipts
 
 | Layer | Status | Receipt | Current artifact |
 |---|---|---|---|
-| Structure | PASS | STRUCT-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
-| Document quality | PASS | QUALITY-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
-| Implementation | PASS | IMPL-20260808-004 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
+| Structure | PASS | STRUCT-20260808-005 | [.requirements-status.json](.requirements-status.json) `validation.structure` |
+| Document quality | PASS | QUALITY-20260808-005 | [.requirements-status.json](.requirements-status.json) `validation.documentQuality` |
+| Implementation | PASS | IMPL-20260808-005 | [.requirements-status.json](.requirements-status.json) `validation.implementation` |
 
 The canonical validator, manual product-contract review, and focused implementation audit are independent. Counts, hashes, source commit, commands, timestamps, warning dispositions, and evidence summaries live only in the derived status artifact.

--- a/src/cli-stream-errors.test.ts
+++ b/src/cli-stream-errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import {
+	handleCliStdoutError,
+	installCliStdoutErrorHandler,
+	isBrokenPipeError,
+} from "./cli-stream-errors.ts";
+
+const MODULE_PATH = path.resolve(import.meta.dir, "cli-stream-errors.ts");
+
+async function emitStreamError(
+	stream: "stderr" | "stdout",
+	code: string
+): Promise<{ exitCode: number; stderr: string }> {
+	const script = `
+		const { installCliStdoutErrorHandler } = await import(${JSON.stringify(MODULE_PATH)});
+		installCliStdoutErrorHandler();
+		const error = Object.assign(new Error("forced ${stream} failure"), { code: ${JSON.stringify(code)} });
+		process.${stream}.emit("error", error);
+	`;
+	const child = Bun.spawn(["bun", "-e", script], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stderr, exitCode] = await Promise.all([
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+
+	return { exitCode, stderr };
+}
+
+describe("CLI stream errors", () => {
+	test("recognizes only EPIPE errors as closed pipes", () => {
+		expect(
+			isBrokenPipeError(Object.assign(new Error("closed"), { code: "EPIPE" }))
+		).toBe(true);
+		expect(
+			isBrokenPipeError(Object.assign(new Error("failed"), { code: "EIO" }))
+		).toBe(false);
+		expect(isBrokenPipeError(new Error("missing code"))).toBe(false);
+	});
+
+	test("rethrows non-EPIPE stdout errors", () => {
+		const error = Object.assign(new Error("forced stdout failure"), {
+			code: "EIO",
+		});
+
+		expect(() => {
+			handleCliStdoutError(error);
+		}).toThrow(error);
+	});
+
+	test("keeps non-EPIPE stdout failures visible and non-zero", async () => {
+		const result = await emitStreamError("stdout", "EIO");
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("forced stdout failure");
+		expect(result.stderr).toContain("EIO");
+	});
+
+	test("does not swallow stderr EPIPE failures", async () => {
+		const result = await emitStreamError("stderr", "EPIPE");
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("forced stderr failure");
+		expect(result.stderr).toContain("EPIPE");
+	});
+
+	test("installs only the exported stdout handler", () => {
+		const stdoutListenersBefore = process.stdout.listenerCount("error");
+		const stderrListenersBefore = process.stderr.listenerCount("error");
+
+		installCliStdoutErrorHandler();
+
+		expect(process.stdout.listenerCount("error")).toBe(
+			stdoutListenersBefore + 1
+		);
+		expect(process.stderr.listenerCount("error")).toBe(stderrListenersBefore);
+		process.stdout.off("error", handleCliStdoutError);
+	});
+});

--- a/src/cli-stream-errors.ts
+++ b/src/cli-stream-errors.ts
@@ -1,0 +1,19 @@
+function hasErrorCode(error: unknown): error is { code: unknown } {
+	return typeof error === "object" && error !== null && "code" in error;
+}
+
+export function isBrokenPipeError(error: unknown): boolean {
+	return hasErrorCode(error) && error.code === "EPIPE";
+}
+
+export function handleCliStdoutError(error: Error): void {
+	if (isBrokenPipeError(error)) {
+		process.exit(0);
+	}
+
+	throw error;
+}
+
+export function installCliStdoutErrorHandler(): void {
+	process.stdout.on("error", handleCliStdoutError);
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,4 +1,43 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const CLI = ["bun", path.resolve(import.meta.dir, "cli.ts")];
+const JSON_PIPE_FIXTURE_FILE_COUNT = 800;
+const JSON_PIPE_EXPORTS_PER_FILE = 12;
+const HUMAN_PIPELINE = 'bun "$@" | head -n 1';
+const JSON_PIPELINE = 'bun "$@" | head -c 1';
+
+async function runWithClosedStdout(args: string[], pipeline: string) {
+	const child = Bun.spawn(
+		[
+			"bash",
+			"-o",
+			"pipefail",
+			"-c",
+			pipeline,
+			"resect-pipeline",
+			...CLI.slice(1),
+			...args,
+		],
+		{
+			stdout: "pipe",
+			stderr: "pipe",
+		}
+	);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+
+	return {
+		exitCode,
+		stderr,
+		stdout,
+	};
+}
 
 describe("cli", () => {
 	test("--version returns version", async () => {
@@ -78,5 +117,55 @@ describe("cli", () => {
 
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("Usage: resect discover <directory> [options]");
+	});
+
+	test("exits quietly when a human-output reader closes stdout", async () => {
+		const result = await runWithClosedStdout(
+			["discover", process.cwd()],
+			HUMAN_PIPELINE
+		);
+
+		expect(result.stdout.length).toBeGreaterThan(0);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).not.toContain("EPIPE");
+	});
+
+	test("exits quietly when a JSON-output reader closes stdout", async () => {
+		const fixtureRoot = await mkdtemp(
+			path.join(tmpdir(), "resect-cli-json-pipe-")
+		);
+
+		try {
+			await Bun.write(
+				path.join(fixtureRoot, "tsconfig.json"),
+				JSON.stringify({ include: ["src/**/*.ts"] })
+			);
+			await Promise.all(
+				Array.from(
+					{ length: JSON_PIPE_FIXTURE_FILE_COUNT },
+					async (_, index) => {
+						await Bun.write(
+							path.join(fixtureRoot, "src", `file-${index}.ts`),
+							Array.from(
+								{ length: JSON_PIPE_EXPORTS_PER_FILE },
+								(__, exportIndex) =>
+									`export const value${index}_${exportIndex} = ${exportIndex};`
+							).join("\n")
+						);
+					}
+				)
+			);
+
+			const result = await runWithClosedStdout(
+				["audit", fixtureRoot, "--json"],
+				JSON_PIPELINE
+			);
+
+			expect(result.stdout).toHaveLength(1);
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).not.toContain("EPIPE");
+		} finally {
+			await rm(fixtureRoot, { recursive: true, force: true });
+		}
 	});
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { parseArgs } from "node:util";
 import { version } from "../package.json";
 import { logger } from "./cli-logger.ts";
+import { installCliStdoutErrorHandler } from "./cli-stream-errors.ts";
 import { CLI_NAME, formatCommandList } from "./commands/command-spec.ts";
 import { applyResectConfigToCliValues } from "./commands/config-defaults.ts";
 import {
@@ -16,6 +17,8 @@ import {
 	loadResectConfig,
 	resolveResectConfig,
 } from "./core/project-config.ts";
+
+installCliStdoutErrorHandler();
 
 const cliArgs = Bun.argv.slice(2);
 const rawArgs = preprocessArgs(cliArgs);


### PR DESCRIPTION
## Summary
- handle expected stdout EPIPE once at the CLI process boundary
- cover both logger-driven human output and direct JSON output through real OS pipelines
- keep non-EPIPE stdout errors and all stderr errors visible and non-zero
- add verified CLI-001 and CLI-002 requirements with current receipts

## Why
Unix consumers such as head intentionally close stdout after receiving enough data. Resect currently turns that normal pipeline lifecycle into a Bun stack trace and exit 1.

Closes #192

## Testing
- bun test src/cli-stream-errors.test.ts src/cli.test.ts --timeout=20000 --parallel=4 (13 passed, 0 failed, 32 assertions)
- bun test --timeout=20000 --parallel=4 (954 passed, 0 failed, 2745 assertions across 72 files)
- pnpm run check
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- pnpm run build:lib
- pnpm run verify:size
- canonical requirements validator and assert-canonical (46 scenarios, 0 structural errors)

## Risk / Rollout
Low and CLI-only. The new listener exits successfully only for stdout errors with code EPIPE. Other stdout errors are rethrown, stderr is untouched, and MCP/library behavior is unchanged.

## Evidence
- set -o pipefail with discover piped to head now reports producer and consumer statuses 0 0 with no stack trace
- human and JSON subprocess regressions close their downstream reader early
- the documented V1/P1 priority-skew warning is retained with reviewer disposition; the four-item P0 critical path is unchanged